### PR TITLE
Clarify ops-domain ownership boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,22 @@
 
 ## What this is
 
-A vendor-neutral, contract-first specification bundle for DevSecOps/AIOps-style operational intelligence:
-event/topic taxonomy, message envelope conventions, entity extraction mapping DSL, and governance/process docs.
+An AI4IT / Watson-style operational intelligence backend and measurement plane for logs, telemetry, service desk automation, chatops, ticket clustering, reusable evidence artifacts, and operational learning loops.
+
+This repository defines the operations-domain specialization, including:
+- AI4IT topic ladder
+- ops entity extraction schemas
+- mapping DSL
+- story grouping
+- explainability and feedback loops
+- operational measurement plane
+
+This repository does not own platform storage standards or knowledge standards.
+
+Ownership boundaries:
+- `socioprophet-standards-storage` owns base transport, storage, and interface invariants, including canonical envelope and wire contracts.
+- `ontogenesis` and `socioprophet-standards-knowledge` own ontology and knowledge semantics.
+- `global-devsecops-intelligence` owns the operations-domain profile built on those upstream standards.
+
+Dependency direction:
+`platform standards -> knowledge / ontology standards -> global-devsecops-intelligence domain profile -> runtime implementations`

--- a/open-ai4it-spec/README.md
+++ b/open-ai4it-spec/README.md
@@ -1,13 +1,17 @@
 # Open AI4IT Contracts & Modules (rewrite)
 
-This repo skeleton is an **open-source re-specification** of an AI-for-IT event pipeline and entity-extraction system.
-We preserve the functional ideas (topic ladder, message envelope, mapping-driven extraction) while removing vendor coupling.
+This repo skeleton captures the AI4IT operations-domain profile of an AI-for-IT event pipeline and entity-extraction system.
+It preserves the functional ideas relevant to this repository (topic ladder, ops extraction, mapping-driven specialization) while avoiding vendor coupling.
 
-## What is contractually stable (must not drift)
-- Event Envelope: `contracts/schemas/event-envelope.schema.json`
+Canonical platform storage, transport, and interface invariants are owned upstream by `socioprophet-standards-storage`.
+Canonical ontology and knowledge semantics are owned upstream by `ontogenesis` and `socioprophet-standards-knowledge`.
+
+Within this repository, the operations-domain profile that should remain aligned includes:
 - Entity Extraction Output keys: `contracts/schemas/entity-output.schema.json`
 - Mapping DSL schema: `modules/openentitymap/mapping.schema.json`
 - Topic taxonomy + release profiles: `contracts/topics/topics.yaml`
+
+The local event envelope material here is a repository copy/example for integration work, not the canonical ownership source.
 
 ## Modules (independently replaceable)
 - source_adapters/: ingest vendor data -> emit raw topics


### PR DESCRIPTION
Clarifies that global-devsecops-intelligence defines the AI4IT operational domain profile and does not own platform storage or ontology standards.