### PR TITLE
docs: add AI4IT support observability loop design

### DIFF
--- a/docs/architecture/ops-ingestion-and-measurement-plane.md
+++ b/docs/architecture/ops-ingestion-and-measurement-plane.md
@@ -1,0 +1,131 @@
+# Ops Ingestion and Measurement Plane
+
+## Purpose
+
+This document defines the operations-domain ingestion and measurement plane for `global-devsecops-intelligence`.
+
+The goal is to normalize logs, telemetry, tickets, chatops events, anomalies, incident stories, metering, and explainability into a governed AI4IT operational intelligence layer that can be consumed by support, premium support, search, runtime evaluation, and bounded agent execution.
+
+## Repository boundary
+
+`global-devsecops-intelligence` owns the operations-domain profile built on top of upstream platform and ontology standards.
+
+It does **not** own:
+
+- base transport and storage invariants
+- canonical ontology semantics
+- generic runtime execution fabrics
+
+Those are upstream concerns owned by `socioprophet-standards-storage`, `ontogenesis`, and runtime repos such as `prophet-platform` and `agentplane`.
+
+## Required upstream dependencies
+
+### Semantic layer
+`ontogenesis` defines the semantic classes and relationships for:
+
+- `LogEvent`
+- `TelemetryEvent`
+- `TicketEvent`
+- `ChatOpsEvent`
+- `AnomalyFinding`
+- `IncidentStory`
+- `MeterRecord`
+- `OpsRecommendation`
+- `OpsEvidenceArtifact`
+- `SupportOpsContext`
+
+### Transport and storage layer
+`socioprophet-standards-storage` defines:
+
+- canonical envelopes
+- wire contracts
+- storage portability and retention profiles
+- schema versioning rules
+- base validation gates
+
+## Ingestion pipeline
+
+```text
+Raw source
+  -> envelope / transport validation
+  -> semantic class resolution
+  -> ops entity extraction
+  -> topic ladder classification
+  -> grouping / correlation
+  -> anomaly detection and scoring
+  -> metering normalization
+  -> explainability packaging
+  -> evidence artifact generation
+  -> downstream query / support / eval / memory consumers
+```
+
+## Accepted source classes
+
+### Logs
+Application logs, service logs, security logs, audit logs, infrastructure logs, deployment logs.
+
+### Telemetry
+Metrics, traces, counters, SLO signals, resource saturation, quality and latency signals.
+
+### Service desk and workflow
+Ticket systems, case systems, change approvals, escalation workflows, support summaries.
+
+### ChatOps and collaboration
+Matrix room events, support-room events, human-agent workflow annotations, collaboration-derived incident evidence.
+
+## Canonical processing stages
+
+### 1. Entity extraction
+Extract services, systems, environments, tenants, teams, route surfaces, workflow identifiers, ticket IDs, knowledge assets, and support interactions.
+
+### 2. Topic ladder mapping
+Map observations into the AI4IT topic ladder so downstream consumers can reason over a stable operational taxonomy.
+
+### 3. Story grouping
+Convert fragmented observations into coherent `IncidentStory` and `OperationalStory` groupings.
+
+### 4. Anomaly processing
+An anomaly is not merely a spike. It must become a typed, explainable finding with confidence, severity, scope, and evidence lineage.
+
+### 5. Metering normalization
+Metering must include not only cost and usage, but support load, asset reuse rate, recommendation acceptance, anomaly frequency, time to resolution, premium-support uplift, and runbook effectiveness.
+
+### 6. Explainability packaging
+Every operationally significant grouping should support an explainability layer that can be surfaced in support and Matrix chatops contexts.
+
+### 7. Evidence artifact generation
+Create reusable evidence bundles that can be attached to support responses, recommendations, escalations, promotions, and replay workflows.
+
+## Downstream consumers
+
+### Support and premium support
+Support agents consume normalized incident stories, anomaly findings, meter records, and evidence artifacts rather than raw telemetry.
+
+### Sherlock query plane
+`Sherlock-search` should query this repo's normalized ops-domain plane rather than inspect raw source streams directly.
+
+### Memory Mesh
+`memory-mesh` receives long-horizon retained operational memory derived from normalized findings and resolution outcomes.
+
+### Meshrush
+`meshrush` consumes short-horizon pressure from fresh anomaly and metering outputs for rapid adaptation.
+
+### Prophet Platform
+`prophet-platform` hosts runtime APIs, dashboards, preview, and evaluation services over the normalized ops-domain objects.
+
+### Agentplane
+`agentplane` can execute bounded diagnostics, remediation bundles, replay, or evidence-linked actions using normalized operational context.
+
+## Hard rules
+
+1. No support or premium-support action should rely on raw telemetry directly.
+2. No anomaly should be surfaced without explainability lineage and evidence references.
+3. Metering must be queryable at both generic and tier-aware support scopes.
+4. Story grouping and ops-domain interpretation happen here before downstream consumption.
+
+## Immediate implementation tranche
+
+1. Define the ops-domain object model and schema contracts.
+2. Add entity extraction and topic-ladder mapping semantics.
+3. Add anomaly, story-grouping, and metering normalization contracts.
+4. Expose runtime query surfaces to Sherlock, support agents, and evaluation services.

--- a/docs/architecture/support-and-premium-support-ai4it-loop.md
+++ b/docs/architecture/support-and-premium-support-ai4it-loop.md
@@ -1,0 +1,42 @@
+# Support and Premium Support AI4IT Loop Design
+
+## Purpose
+This document outlines the design for integrating Sherlock-queryable operations intelligence and AI4IT feedback loops into support and premium support workflows.
+
+Support and premium support will leverage a combination of operational intelligence (logs, anomalies, metering, ticket groupings), Sherlock for query resolution, and AI4IT-driven escalation and recommendation systems.
+
+## Workflow
+1. **Support and Premium Support Integration**
+   - Both support and premium support agents will query `global-devsecops-intelligence` for normalized operational intelligence, including anomaly findings, meter records, service health, and incident stories.
+   - Queries will be resolved using Sherlock's governed query plane and Matrix chatops interface.
+   - The query response will include citations, evidence artifacts, operational context, and where applicable, next-best-action suggestions and human-reviewable escalation recommendations.
+
+2. **Operations Intelligence Ingestion**
+   - `global-devsecops-intelligence` will process logs, telemetry, tickets, chatops events, anomalies, metering, and service health signals into a normalized ops-domain profile.
+   - Support and premium support agents will be provided with this intelligence in the form of `IncidentStory`, `AnomalyFinding`, and `MeterRecord` objects.
+
+3. **AI4IT Feedback Loop**
+   - AI4IT will enable automated feedback to improve support outcomes, learning quality, and operational efficiency.
+   - Key sources of feedback: operational performance metrics, ticket and service desk analysis, AI4IT-generated anomaly detection and recommendations, and service health alerts.
+   - Sherlock will surface AI4IT-driven recommendations and escalations, dynamically adjusting thresholds for premium support.
+
+4. **Escalation Management**
+   - Escalation packets will be generated based on specific triggers and routed to the appropriate support tier or human SME for review.
+   - Support tiers include Standard Support, Premium Support, and Mission-Critical Support.
+
+## Integration with Sherlock
+- Sherlock will operate as the query and orchestration plane, facilitating seamless integrations between support workflows and operational intelligence.
+- Query responses will include rich metadata, citations, and evidence artifacts that help support agents make informed decisions.
+- Sherlock’s Matrix chatops integration will enhance agent workflows by enabling query resolution and feedback loops within collaborative, team-based chatrooms.
+
+## Object Model
+- Support and premium support queries will return enriched objects, such as:
+   - `SupportOpsContext`: Contains operational context for the support request.
+   - `QueryResultSet`: The results of an AI4IT query from the `global-devsecops-intelligence` ops-plane.
+   - `OpsRecommendation`: Recommendations generated for the support request.
+   - `EscalationPacket`: Contains escalation context, recommendation, and linked operational findings.
+
+## Next Steps
+1. Define the support/premium-support object models and contract definitions.
+2. Build integrations between Sherlock query plane and premium support system.
+3. Integrate feedback loops into AI4IT and operational intelligence processing pipeline.

--- a/docs/devops/metering-anomaly-feedback-pipeline.md
+++ b/docs/devops/metering-anomaly-feedback-pipeline.md
@@ -1,0 +1,33 @@
+# Metering and Anomaly Feedback Pipeline Design
+
+## Purpose
+This document outlines the design of the metering and anomaly feedback pipeline for integrating operational intelligence, feedback loops, and metering outputs into the support ecosystem.
+
+## Pipeline Overview
+1. **Metering Sources**
+   - Metering sources include telemetry data, support tickets, logs, and anomalies from `global-devsecops-intelligence`.
+   - Sources will be normalized and mapped into a standardized feedback model.
+
+2. **Signal Processing**
+   - Signals from the above sources will be processed to detect anomalies, service health issues, operational bottlenecks, and cost inefficiencies.
+   - Raw telemetry will be converted into actionable insights using the `AI4IT` processing layer.
+
+3. **Feedback Loop**
+   - The feedback loop will monitor the flow of operational data and continuously feed back into the system to improve the performance of support workflows.
+   - This loop will include the creation of performance metrics, detection thresholds, and post-resolution ticket handling.
+
+4. **Anomaly Detection and Resolution**
+   - Anomalies will be detected using a blend of machine learning-based anomaly detection models and pre-defined thresholding rules.
+   - Detected anomalies will trigger alerts and initiate corrective actions if necessary.
+
+5. **Integration with Support Systems**
+   - Feedback loops and anomaly resolutions will be integrated into the Sherlock query plane, providing real-time data to support and premium support agents.
+
+6. **Operational Intelligence and Escalations**
+   - By continuously measuring system performance and customer outcomes, Sherlock will integrate with feedback systems for escalations based on predefined rules.
+   - Feedback will influence the prioritization of support cases, affecting resolution time and agent actions.
+
+## Immediate Next Steps
+1. Define metering and anomaly processing models and contract specifications.
+2. Add metering normalization and anomaly scoring functions to `global-devsecops-intelligence`.
+3. Build integration pathways from `sherlock-search` to the feedback loop system for real-time queryable anomaly resolutions.


### PR DESCRIPTION
## Summary
- add ops ingestion and measurement plane architecture
- add support and premium support AI4IT loop design
- add metering and anomaly feedback pipeline design

## Why
This captures the AI4IT operational-intelligence substrate for logs, anomalies, metering, support, and query integration so downstream runtime and search work can bind to a normalized ops-domain profile.

## Notes
- Draft PR for review
- Follows the repo's declared boundary: ops-domain specialization here, ontology and storage invariants upstream
