### PR TITLE
docs(ops): add operational exhaust and trader-agent fusion boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 - `docs/vision/ai4it-home-rewrite.md`
 - `docs/architecture/api-interactions-decision.md`
 - `docs/devops/devops-process-open.md`
+- `docs/devops/operational-exhaust-and-trader-agent-fusion.md`
 - `docs/adr/0001-ops-domain-profile-and-external-seed-boundary.md`
+- `docs/adr/0002-operational-exhaust-and-trader-agent-fusion-boundary.md`
 - `docs/architecture/github-footprint-itops-alignment.md`
 - `profiles/github-footprint-itops-expansion.yaml`
+- `profiles/operational-exhaust-fusion-profile.v0.yaml`
 - `third_party/ibm-itops/UPSTREAM.md`
 - `third_party/ibm-itops/IMPORT-MANIFEST.v2.json`
 - `third_party/ibm-itops/LICENSE.Apache-2.0`
@@ -15,7 +18,7 @@
 
 ## What this is
 
-An operations-domain profile for DevSecOps / AIOps / AI4IT operational intelligence: logs, telemetry, service desk automation, chatops, ticket clustering, reusable evidence artifacts, operational learning loops, derived operational graph projections, and now an explicit GitHub-footprint / website-surface alignment layer.
+An operations-domain profile for DevSecOps / AIOps / AI4IT operational intelligence: logs, telemetry, service desk automation, chatops, ticket clustering, reusable evidence artifacts, operational learning loops, derived operational graph projections, an explicit GitHub-footprint / website-surface alignment layer, and now a governed operational-exhaust fusion layer for platform and trader-agent telemetry.
 
 This repository defines the operations-domain specialization, including:
 - AI4IT topic ladder
@@ -28,6 +31,7 @@ This repository defines the operations-domain specialization, including:
 - mappings from external ontologies into the operations-domain profile
 - evidence-oriented operational graph projections scoped to this profile
 - GitHub footprint alignment against workspace topology, ontology scaffolding, and website surface taxonomy
+- operational exhaust fusion across CI/CD, runtime, policy/evidence, market/execution, and trader-agent lanes
 
 This repository does not own canonical platform storage standards, canonical wire contracts, or the sole canonical platform ontology / broader knowledge semantics.
 
@@ -43,6 +47,7 @@ Institutional digital-twin semantics may appear here only insofar as they are ne
 - IBM ITOPS is present here as a metadata-first external seed import under `third_party/ibm-itops/`.
 - `GLO_V1.ttl` remains the preferred first payload for semantic alignment.
 - Stage payloads (`ITOPS_S1`, `ITOPS_S2`, `ITOPS_S3`) remain deferred until vendoring, validation, and query strategy are approved.
+- Ge Chu / Alexei Lisitsa-style ontology- and BDI-agent-based security automation is a candidate **ops-domain seed influence** only; any adoption here must remain a mapped specialization rather than a replacement for canonical platform ontology ownership.
 
 ## Current GitHub-footprint alignment status
 
@@ -51,6 +56,12 @@ Institutional digital-twin semantics may appear here only insofar as they are ne
 - the website surface inventory and public docs provide the normalized operational taxonomy for surfaces, workflow states, provider states, and capability routing.
 - `docs/architecture/github-footprint-itops-alignment.md` explains the integration model.
 - `profiles/github-footprint-itops-expansion.yaml` provides the first machine-readable profile stub.
+
+## Current operational-exhaust fusion status
+
+- `docs/devops/operational-exhaust-and-trader-agent-fusion.md` defines the ops-domain fusion model for platform and trader-agent exhaust.
+- `profiles/operational-exhaust-fusion-profile.v0.yaml` provides the first machine-readable fusion profile.
+- `docs/adr/0002-operational-exhaust-and-trader-agent-fusion-boundary.md` defines the ownership boundary for this projection.
 
 Dependency direction:
 `platform standards -> knowledge / ontology standards -> global-devsecops-intelligence operations-domain profile -> runtime implementations`

--- a/docs/adr/0002-operational-exhaust-and-trader-agent-fusion-boundary.md
+++ b/docs/adr/0002-operational-exhaust-and-trader-agent-fusion-boundary.md
@@ -1,0 +1,59 @@
+# ADR 0002: Operational Exhaust and Trader-Agent Fusion Boundary
+
+## Status
+Proposed
+
+## Context
+
+`global-devsecops-intelligence` already defines itself as the operations-domain specialization for DevSecOps / AIOps / AI4IT operational intelligence.
+That declared scope already includes logs, telemetry, reusable evidence artifacts, operational measurement, learning loops, and derived operational graph projections.
+
+Two pressure points now need an explicit boundary decision:
+
+1. platform operational exhaust is being emitted across CI/CD, runtime services, agent surfaces, policy/evidence lanes, and deployment control planes;
+2. trader-agent systems will emit the same class of operational exhaust, but with market-data, strategy-run, execution, risk-control, and replay-specific fields.
+
+Without an explicit boundary, these streams could drift into:
+- repo-local telemetry silos,
+- duplicated observability grammars across platform vs trader-agent systems,
+- or accidental redefinition of canonical storage, wire, or ontology semantics inside an ops-domain repository.
+
+## Decision
+
+This repository SHALL own the **operations-domain projection** for operational exhaust fusion across:
+- CI/CD and delivery telemetry,
+- runtime/service/agent health telemetry,
+- policy/evidence receipts,
+- market-data and execution operations telemetry,
+- trader-agent learning-loop and post-run operational feedback signals.
+
+This repository SHALL NOT become the canonical home for:
+- canonical wire contracts,
+- canonical storage semantics,
+- canonical market or portfolio ontology semantics,
+- or the sole canonical platform ontology.
+
+Canonical boundaries remain:
+- `socioprophet-standards-storage` for base transport, storage, and interface invariants,
+- `ontogenesis` and `socioprophet-standards-knowledge` for canonical ontology and broader knowledge semantics,
+- domain runtimes and standards repositories for domain-native event semantics.
+
+This repository only owns:
+- the ops-domain projection,
+- the mapping of upstream events into ops-domain operational intelligence,
+- story grouping and correlation,
+- operational measurement and feedback loops,
+- and derived operational graph views.
+
+## Consequences
+
+- Platform telemetry and trader-agent telemetry can share one evidence grammar and one fusion layer without collapsing their canonical semantics into the same upstream model.
+- Sensitive raw payloads should be referenced by artifact handles, hashes, and evidence receipts rather than copied wholesale into ops-domain projections.
+- Trader-agent telemetry can be fused with DevSecOps / AIOps telemetry for incident analysis, policy review, and operational learning while preserving domain ownership boundaries.
+- External influences such as Ge Chu / Alexei Lisitsa-style ontology- and BDI-agent-based security automation may be used as mapped seed influences for the ops-domain profile, but must not replace canonical platform ontology ownership.
+
+## Follow-on requirements
+
+- Add a machine-readable operational exhaust fusion profile.
+- Add ops-domain mappings for trader-agent operational projections.
+- Add runtime-side emitter guidance so platform and trader-agent systems emit compatible evidence-oriented exhaust.

--- a/docs/devops/operational-exhaust-and-trader-agent-fusion.md
+++ b/docs/devops/operational-exhaust-and-trader-agent-fusion.md
@@ -1,0 +1,142 @@
+# Operational Exhaust and Trader-Agent Fusion
+
+## Purpose
+
+This document defines the first operations-domain fusion model for platform telemetry, operational event exhaust, and trader-agent operational telemetry.
+
+The goal is not to relocate canonical platform or market semantics into this repository.
+The goal is to define how those upstream signals are projected into one ops-domain intelligence surface for:
+- correlation,
+- incident grouping,
+- feedback loops,
+- measurement,
+- policy review,
+- replay alignment,
+- and operational learning.
+
+## Why this needs to exist
+
+Today, operational exhaust is produced across multiple planes:
+- CI and delivery pipelines,
+- runtime services and agent surfaces,
+- policy/evidence and authorization lanes,
+- market-data ingestion and replay lanes,
+- trader-agent execution and learning loops.
+
+If these are captured independently, the result is a fragmented observability posture.
+We instead want one governed operational fusion surface.
+
+## Authority split
+
+- canonical storage, wire, and interface invariants remain upstream in `socioprophet-standards-storage`
+- canonical ontology and broader knowledge semantics remain upstream in `ontogenesis` and `socioprophet-standards-knowledge`
+- runtime and domain repositories continue to own domain-native event semantics
+- `global-devsecops-intelligence` owns the **ops-domain projection**, mapping, grouping, and derived operational graph surfaces
+
+## Fusion lanes
+
+### 1. CI / delivery lane
+Examples:
+- build started / finished
+- test suite started / finished
+- deployment requested / applied / rolled back
+- dependency risk detection
+- provenance and attestation publication
+
+### 2. Runtime / service / agent lane
+Examples:
+- service health
+- queue pressure
+- saturation and shed posture
+- route or dependency degradation
+- agent lifecycle transitions
+- capability or tool availability changes
+
+### 3. Policy / evidence lane
+Examples:
+- policy decision emitted
+- authorization denied
+- grant or delegation activated
+- attestation verified / failed
+- replay receipt emitted
+- evidence bundle sealed
+
+### 4. Market-data operations lane
+Examples:
+- feed connected / degraded / disconnected
+- gap detected
+- late or out-of-order observations detected
+- replay requested / completed
+- calendar or symbol-map version changes
+- corporate-action restatement activity
+
+### 5. Trader-agent execution lane
+Examples:
+- strategy run started / stopped
+- model version selected
+- feature snapshot pinned
+- order intent created
+- broker or venue acknowledgement
+- fill / reject / cancel
+- kill-switch or risk control activation
+- execution-quality measurement and slippage evaluation
+
+### 6. Trader-agent learning lane
+Examples:
+- post-trade evaluation completed
+- replay/backtest parity result emitted
+- policy violation review generated
+- strategy promotion / demotion recommendation
+- operator override or escalation
+
+## Common required projection fields
+
+Every projected operational event SHOULD carry:
+- `event_id`
+- `observed_at`
+- `source_repo`
+- `source_surface`
+- `source_runtime`
+- `environment_ref`
+- `actor_ref` or `agent_ref`
+- `trace_ref`
+- `story_ref` when applicable
+- `policy_ref` when applicable
+- `evidence_ref` or `artifact_ref`
+- `severity` or `operational_band`
+- `projection_family`
+
+## Trader-agent-specific projection fields
+
+Trader-agent operational events SHOULD also carry, where applicable:
+- `strategy_run_ref`
+- `model_ref`
+- `feature_snapshot_ref`
+- `market_window_ref`
+- `risk_policy_ref`
+- `order_intent_ref`
+- `execution_ref`
+- `venue_ref`
+- `portfolio_scope_ref`
+- `replay_ref`
+- `post_trade_evaluation_ref`
+
+## Export and retention rules
+
+- Raw sensitive payloads SHOULD remain in their canonical stores and be referenced here by artifact handles, hashes, or receipts.
+- This repository SHOULD store projection-ready artifacts, mappings, and intelligence views, not become the canonical store for all source payloads.
+- Derived operational graph projections may join CI/CD, runtime, policy/evidence, market-data, and trader-agent signals into one incident or learning story.
+
+## External influence note
+
+A relevant upstream influence for the security-automation side is Ge Chu / Alexei Lisitsa-style ontology- and BDI-agent-based automation of penetration testing.
+This is relevant here as an **ops-domain seed influence** for automation, reasoning, and operational planning.
+It does not alter the canonical ontology ownership boundary.
+
+## Immediate next uses
+
+- unify DevSecOps / AIOps telemetry with agent-plane telemetry
+- provide a stable fusion grammar for trader-agent operational exhaust
+- support cross-plane incident grouping
+- support replay-aware operational learning
+- support evidence-oriented audit and policy review

--- a/profiles/operational-exhaust-fusion-profile.v0.yaml
+++ b/profiles/operational-exhaust-fusion-profile.v0.yaml
@@ -1,0 +1,89 @@
+apiVersion: global-devsecops-intelligence.socioprophet.org/v0alpha1
+kind: OperationalExhaustFusionProfile
+metadata:
+  name: platform-and-trader-agent-fusion
+spec:
+  purpose: >
+    Fuse platform, agent, DevSecOps, market-data, and trader-agent operational
+    exhaust into a single ops-domain intelligence projection surface.
+  ownership_boundary:
+    canonical_storage_and_wire: SocioProphet/socioprophet-standards-storage
+    canonical_ontology:
+      - SocioProphet/ontogenesis
+      - SocioProphet/socioprophet-standards-knowledge
+    operations_domain_projection: SocioProphet/global-devsecops-intelligence
+  lanes:
+    - id: ci_delivery
+      examples:
+        - build.started
+        - build.finished
+        - tests.finished
+        - deployment.applied
+        - deployment.rollback
+    - id: runtime_service_agent
+      examples:
+        - service.health
+        - queue.pressure
+        - route.degraded
+        - agent.lifecycle
+        - capability.changed
+    - id: policy_evidence
+      examples:
+        - policy.decision
+        - authorization.denied
+        - attestation.verified
+        - replay.receipt
+        - evidence.bundle.sealed
+    - id: market_data_operations
+      examples:
+        - feed.connected
+        - feed.degraded
+        - gap.detected
+        - observations.late
+        - replay.completed
+    - id: trader_agent_execution
+      examples:
+        - strategy_run.started
+        - model.selected
+        - order_intent.created
+        - order.filled
+        - order.rejected
+        - risk_control.activated
+    - id: trader_agent_learning
+      examples:
+        - post_trade.completed
+        - replay.parity.completed
+        - strategy.promotion_recommended
+        - operator.override
+  common_required_fields:
+    - event_id
+    - observed_at
+    - source_repo
+    - source_surface
+    - source_runtime
+    - environment_ref
+    - trace_ref
+    - projection_family
+  trader_agent_required_fields:
+    - strategy_run_ref
+    - model_ref
+    - feature_snapshot_ref
+    - market_window_ref
+    - risk_policy_ref
+    - order_intent_ref
+    - execution_ref
+    - venue_ref
+  sinks:
+    - operational_graph_projection
+    - incident_story_grouping
+    - feedback_loop
+    - replay_alignment
+    - policy_review
+  export_rules:
+    raw_sensitive_payloads: reference_only
+    canonical_market_semantics_owned_here: false
+    canonical_wire_semantics_owned_here: false
+  external_seed_candidates:
+    - name: ge-chu-bdi-ontology-pentest-automation
+      role: ops_domain_seed_influence_only
+      status: candidate


### PR DESCRIPTION
## Summary
- add ADR 0002 for operational exhaust and trader-agent fusion boundary
- add a first ops-domain fusion note for platform and trader-agent exhaust
- add a first machine-readable `OperationalExhaustFusionProfile`
- update the README to register the new fusion surfaces

## Why
`global-devsecops-intelligence` already owns the operations-domain profile, measurement plane, evidence-oriented projections, and operational graph views. This PR makes that role explicit for:
- platform telemetry and operational exhaust
- CI/CD and runtime/service/agent telemetry
- policy/evidence receipts
- market-data operations telemetry
- trader-agent execution and learning exhaust

The key boundary remains intact:
- canonical storage and wire invariants stay upstream in `socioprophet-standards-storage`
- canonical ontology / knowledge semantics stay upstream in `ontogenesis` and `socioprophet-standards-knowledge`
- this repo only owns the ops-domain projection, mapping, grouping, and derived intelligence surfaces

## External influence note
This PR records Ge Chu / Alexei Lisitsa-style ontology- and BDI-agent-based security automation as a candidate ops-domain seed influence only, not as a canonical ontology transfer.

## Follow-on work
- add trader-agent projection mappings
- add runtime-side emitter guidance
- add concrete ops-domain extraction schemas for CI/runtime/policy/market/execution lanes
