### PR TITLE
mappings(ops): add operational exhaust fusion ingestion map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate
+.PHONY: validate test service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate operational-exhaust-fusion-validate
 
-validate: service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate
+validate: service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate operational-exhaust-fusion-validate
 	@echo "OK: validate"
 
 service-desk-metrics-validate:
@@ -11,6 +11,9 @@ model-fabric-release-readiness-validate:
 
 github-footprint-itops-validate:
 	python3 tools/validate_github_footprint_itops.py
+
+operational-exhaust-fusion-validate:
+	python3 tools/validate_operational_exhaust_fusion.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/mappings/operational-exhaust-to-ops-domain.v0.yaml
+++ b/mappings/operational-exhaust-to-ops-domain.v0.yaml
@@ -1,0 +1,53 @@
+apiVersion: global-devsecops-intelligence.socioprophet.org/v0alpha1
+kind: OperationalExhaustOpsDomainMapping
+metadata:
+  name: operational-exhaust-to-ops-domain-v0
+spec:
+  source_contracts:
+    - repo: SocioProphet/prophet-platform
+      path: contracts/OperationalExhaustObserved.v0.1.json
+      projection_family: generic_operational_exhaust
+    - repo: SocioProphet/prophet-platform
+      path: contracts/TraderAgentExecutionObserved.v0.1.json
+      projection_family: trader_agent_execution
+  target_projection:
+    repo: SocioProphet/global-devsecops-intelligence
+    profile: profiles/operational-exhaust-fusion-profile.v0.yaml
+  entity_mappings:
+    event_id: ops:OperationalEvent.id
+    observed_at: ops:OperationalEvent.observedAt
+    source_repo: ops:SourceRepository.name
+    source_surface: ops:SourceSurface.name
+    source_runtime: ops:Runtime.name
+    environment_ref: ops:Environment.ref
+    trace_ref: ops:Trace.ref
+    story_ref: ops:Story.ref
+    agent_ref: ops:Agent.ref
+    policy_ref: ops:Policy.ref
+    evidence_ref: ops:Evidence.ref
+    artifact_ref: ops:Artifact.ref
+    projection_family: ops:OperationalProjection.family
+  trader_agent_mappings:
+    strategy_run_ref: ops:TraderStrategyRun.ref
+    model_ref: ops:ModelVersion.ref
+    feature_snapshot_ref: ops:FeatureSnapshot.ref
+    market_window_ref: ops:MarketWindow.ref
+    risk_policy_ref: ops:RiskPolicy.ref
+    order_intent_ref: ops:OrderIntent.ref
+    execution_ref: ops:Execution.ref
+    venue_ref: ops:Venue.ref
+    portfolio_scope_ref: ops:PortfolioScope.ref
+    replay_ref: ops:Replay.ref
+    post_trade_evaluation_ref: ops:PostTradeEvaluation.ref
+  grouping_keys:
+    - trace_ref
+    - story_ref
+    - strategy_run_ref
+    - market_window_ref
+    - risk_policy_ref
+  projection_rules:
+    raw_sensitive_payloads: reference_only
+    retain_receipts: true
+    derived_graph_allowed: true
+    canonical_market_semantics_owned_here: false
+    canonical_wire_semantics_owned_here: false

--- a/tools/tests/test_operational_exhaust_fusion.py
+++ b/tools/tests/test_operational_exhaust_fusion.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_operational_exhaust_fusion_mapping_validates():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_operational_exhaust_fusion.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/validate_operational_exhaust_fusion.py
+++ b/tools/validate_operational_exhaust_fusion.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Validate operational-exhaust fusion mapping artifacts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except Exception as exc:  # pragma: no cover
+    raise SystemExit("pyyaml is required: install with `python -m pip install pyyaml`") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+MAPPING = ROOT / "mappings" / "operational-exhaust-to-ops-domain.v0.yaml"
+PROFILE = ROOT / "profiles" / "operational-exhaust-fusion-profile.v0.yaml"
+
+REQUIRED_TOP = {"apiVersion", "kind", "metadata", "spec"}
+REQUIRED_SPEC = {
+    "source_contracts",
+    "target_projection",
+    "entity_mappings",
+    "trader_agent_mappings",
+    "grouping_keys",
+    "projection_rules",
+}
+REQUIRED_ENTITY_KEYS = {
+    "event_id",
+    "observed_at",
+    "source_repo",
+    "source_surface",
+    "source_runtime",
+    "environment_ref",
+    "trace_ref",
+    "projection_family",
+}
+REQUIRED_TRADER_KEYS = {
+    "strategy_run_ref",
+    "model_ref",
+    "feature_snapshot_ref",
+    "market_window_ref",
+    "risk_policy_ref",
+    "order_intent_ref",
+    "execution_ref",
+    "venue_ref",
+}
+
+
+def load_yaml(path: Path) -> dict:
+    try:
+        value = yaml.safe_load(path.read_text())
+    except Exception as exc:  # pragma: no cover
+        raise SystemExit(f"failed to parse {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SystemExit(f"{path} did not parse as a mapping")
+    return value
+
+
+def require_keys(label: str, value: dict, required: set[str]) -> list[str]:
+    return sorted(required - set(value.keys()))
+
+
+def main() -> int:
+    failed = False
+    mapping = load_yaml(MAPPING)
+    missing = require_keys("mapping", mapping, REQUIRED_TOP)
+    if missing:
+        print(f"[FAIL] mapping top-level missing: {', '.join(missing)}", file=sys.stderr)
+        failed = True
+    spec = mapping.get("spec", {})
+    if not isinstance(spec, dict):
+        print("[FAIL] mapping spec is not a mapping", file=sys.stderr)
+        return 1
+    missing = require_keys("mapping spec", spec, REQUIRED_SPEC)
+    if missing:
+        print(f"[FAIL] mapping spec missing: {', '.join(missing)}", file=sys.stderr)
+        failed = True
+    entity_mappings = spec.get("entity_mappings", {})
+    trader_mappings = spec.get("trader_agent_mappings", {})
+    missing = require_keys("entity_mappings", entity_mappings, REQUIRED_ENTITY_KEYS)
+    if missing:
+        print(f"[FAIL] entity_mappings missing: {', '.join(missing)}", file=sys.stderr)
+        failed = True
+    missing = require_keys("trader_agent_mappings", trader_mappings, REQUIRED_TRADER_KEYS)
+    if missing:
+        print(f"[FAIL] trader_agent_mappings missing: {', '.join(missing)}", file=sys.stderr)
+        failed = True
+    if not PROFILE.exists():
+        print(f"[FAIL] referenced fusion profile missing: {PROFILE}", file=sys.stderr)
+        failed = True
+    source_contracts = spec.get("source_contracts", [])
+    if len(source_contracts) < 2:
+        print("[FAIL] expected at least two source contracts", file=sys.stderr)
+        failed = True
+    if failed:
+        return 1
+    print("[OK] operational exhaust fusion mapping validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `mappings/operational-exhaust-to-ops-domain.v0.yaml`
- add `tools/validate_operational_exhaust_fusion.py`
- add `tools/tests/test_operational_exhaust_fusion.py`
- wire `operational-exhaust-fusion-validate` into `make validate`

## Why
This is the destination-side counterpart to `prophet-platform` PR #385. It defines how runtime-emitted `OperationalExhaustObserved.v0.1` and `TraderAgentExecutionObserved.v0.1` events project into the global DevSecOps intelligence ops-domain model.

## Boundary
This PR keeps canonical storage/wire semantics and canonical market semantics upstream. It only adds the ops-domain extraction/mapping surface and validation path.

## Related
- `SocioProphet/prophet-platform` PR #385: source-side runtime contracts, examples, and validator
- `SocioProphet/global-devsecops-intelligence` PR #3: merged operational exhaust and trader-agent fusion boundary
