### PR TITLE
Align telemetry with runtime control plane intelligence

### DIFF
--- a/docs/architecture/runtime-control-plane-telemetry-alignment.md
+++ b/docs/architecture/runtime-control-plane-telemetry-alignment.md
@@ -1,0 +1,67 @@
+# Runtime Control Plane Telemetry Alignment
+
+## Purpose
+This document updates the operations telemetry profile after the current platform movement across `prophet-platform`, `policy-fabric`, `agentplane`, and this repository.
+
+The existing telemetry surface profile remains the baseline. This document binds it to the newer evidence and operational intelligence surfaces.
+
+## Current operational anchors
+Operational telemetry SHOULD normalize signals from:
+
+- model-fabric release readiness scorecards,
+- broker operational intelligence bindings,
+- agentic service desk metrics,
+- Policy Fabric diff hygiene gate reports,
+- AgentPlane agentic PR work orders,
+- Prophet Platform runtime dry-run records,
+- Prophet Platform live cluster preflight records,
+- identity context records,
+- parity-readiness records.
+
+## Required canonical references
+Every runtime-control-plane operational signal SHOULD preserve:
+
+- `artifact_digest`
+- `policy_decision_id`
+- `agentplane_run_id`
+- `agentic_pr_work_order_id`
+- `diff_hygiene_gate_report_id`
+- `service_desk_metric_ref`
+- `release_readiness_scorecard_ref`
+- `runtime_dry_run_record_ref`
+- `live_cluster_preflight_record_ref`
+- `identity_context_ref`
+
+## Signal families
+The operations profile SHOULD distinguish:
+
+- `ops.release_readiness.*`
+- `ops.diff_hygiene.*`
+- `ops.agentic_pr.*`
+- `ops.service_desk.*`
+- `ops.runtime_preflight.*`
+- `ops.policy_decision.*`
+- `ops.identity_context.*`
+- `ops.learning_feedback.*`
+
+## Drift detection
+The operations layer SHOULD detect drift between:
+
+- upstream standards and platform runtime docs,
+- policy-fabric gates and platform policy telemetry,
+- agentplane work orders and platform agent run telemetry,
+- identity context schemas and runtime identity references,
+- release readiness scorecards and actual promotion evidence.
+
+## Redaction and evidence handling
+Raw bootstrap captures, browser console dumps, signed URLs, and session-bearing artifacts MUST be redacted before ingestion into durable operational evidence stores.
+
+The canonical object should keep a redaction receipt rather than raw sensitive material.
+
+## Follow-on implementation
+The next implementation tranche SHOULD add schema-backed examples that map:
+
+- Policy Fabric diff hygiene reports to `DetectionSignal` and `PolicyDecision`,
+- AgentPlane work orders to `CorrelationContext` and `LearningFeedback`,
+- platform runtime records to `EvidenceArtifact`,
+- readiness scorecards to `IntelligenceAssertion`.

--- a/mappings/runtime-control-plane-telemetry-v2.yaml
+++ b/mappings/runtime-control-plane-telemetry-v2.yaml
@@ -1,0 +1,95 @@
+version: v2
+profile: runtime-control-plane-telemetry
+purpose: >-
+  Demonstrate how runtime-control-plane evidence from platform, policy, agent, and
+  operational readiness systems normalizes into global DevSecOps intelligence objects.
+source_records:
+  prophet_platform:
+    runtime_dry_run_record_ref: schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
+    live_cluster_preflight_record_ref: schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json
+    identity_context_ref: contracts/identity
+    parity_readiness_ref: tools/check_fogstack_parity_readiness.py
+  policy_fabric:
+    diff_hygiene_gate_report_ref: contracts/policy_fabric_diff_hygiene_gate_report_v0.schema.json
+  agentplane:
+    agentic_pr_work_order_ref: examples/agentic-pr-work-order.example.json
+canonical_objects:
+  TelemetrySignal:
+    required_fields:
+      - event_name
+      - signal_class
+      - source
+      - ts_ms
+      - environment
+      - trace_id
+      - request_id
+    correlation_fields:
+      - agentplane_run_id
+      - policyplane_decision_id
+      - runtime_dry_run_record_ref
+      - live_cluster_preflight_record_ref
+      - identity_context_ref
+      - diff_hygiene_gate_report_id
+      - agentic_pr_work_order_id
+  PolicyDecision:
+    derived_from:
+      - policy_fabric.diff_hygiene_gate_report_ref
+      - prophet_platform.runtime_dry_run_record_ref
+    required_fields:
+      - policy_decision_id
+      - subject_ref
+      - decision
+      - effect
+      - reason
+  EvidenceArtifact:
+    derived_from:
+      - prophet_platform.runtime_dry_run_record_ref
+      - prophet_platform.live_cluster_preflight_record_ref
+      - prophet_platform.parity_readiness_ref
+    required_fields:
+      - artifact_ref
+      - artifact_digest
+      - schema_ref
+      - produced_by
+      - observed_at
+  CorrelationContext:
+    derived_from:
+      - agentplane.agentic_pr_work_order_ref
+      - prophet_platform.identity_context_ref
+    required_fields:
+      - trace_id
+      - request_id
+      - build_id
+      - environment
+      - actor_ref
+normalization_rules:
+  - id: preserve_policy_decision_ref
+    rule: >-
+      Runtime telemetry that references a PolicyPlane or Policy Fabric decision MUST
+      preserve the original decision identifier and decision effect.
+  - id: preserve_agent_work_order_ref
+    rule: >-
+      Agentic work initiated through AgentPlane MUST retain the work-order identifier
+      through platform runtime telemetry and operational intelligence records.
+  - id: preserve_safety_boundary
+    rule: >-
+      Live-preflight telemetry MUST preserve live_apply_allowed, mutated_cluster,
+      human_approval_required, and preflight_status when those fields exist.
+  - id: redact_bootstrap_material
+    rule: >-
+      Raw bootstrap, browser-console, signed URL, or session-bearing evidence MUST be
+      redacted before durable publication; retain a redaction receipt instead.
+topic_bindings:
+  ops.telemetry.signals.v1:
+    accepts:
+      - TelemetrySignal
+      - CorrelationContext
+  ops.policy.decisions.v1:
+    accepts:
+      - PolicyDecision
+  ops.evidence.artifacts.v1:
+    accepts:
+      - EvidenceArtifact
+  ops.learning.feedback.v1:
+    accepts:
+      - CorrelationContext


### PR DESCRIPTION
Add runtime-control-plane telemetry alignment for release readiness, broker ops, service desk metrics, policy-fabric diff hygiene, agentplane work orders, platform runtime records, identity context, and redaction/evidence handling.