### PR TITLE
devops: add client runtime dump exposure finding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate
+.PHONY: validate test service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate
 
-validate: service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate
+validate: service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate
 	@echo "OK: validate"
 
 service-desk-metrics-validate:
@@ -14,6 +14,9 @@ github-footprint-itops-generated-validate:
 
 github-footprint-itops-validate: github-footprint-itops-generated-validate
 	python3 tools/validate_github_footprint_itops.py
+
+client-runtime-dump-exposure-validate:
+	python3 tools/validate_client_runtime_dump_exposure.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/devops/client-runtime-dump-exposure.md
+++ b/docs/devops/client-runtime-dump-exposure.md
@@ -1,0 +1,116 @@
+# Client Runtime Dump Exposure Finding v0.1
+
+## Status
+
+Status: draft finding family.
+
+Related standard: `SocioProphet/socioprophet-standards-knowledge#61` / `docs/standards/052-client-runtime-object-dump-forensics.md`.
+
+## Purpose
+
+`ClientRuntimeDumpExposure` captures a DevSecOps intelligence pattern where a browser console capture, developer-tools object expansion, support paste, screenshot, issue comment, model prompt, telemetry event, or notebook cell exposes sensitive client runtime state.
+
+The triggering application event may be harmless, but the copied runtime graph can leak identity, authentication-adjacent values, page state, route identifiers, build metadata, telemetry session IDs, and framework internals.
+
+## Finding family
+
+Finding family: `ClientRuntimeDumpExposure`
+
+Primary risk: secret and identity exposure through over-broad diagnostic artifacts.
+
+Secondary risk: false root-cause analysis from treating a cyclic browser/runtime graph as a normal application payload.
+
+## Sensitive field classes
+
+GDI detection and review workflows SHOULD flag the following classes:
+
+- `cookie:` fields and semicolon-delimited cookie material;
+- authentication and session markers such as `auth`, `session`, `token`, `sid`, `client-auth-info`, `puid`, and `did`;
+- display names, relay email addresses, account email addresses, avatar URLs, and user identifiers;
+- private page URLs, route IDs, object IDs, conversation IDs, tenant IDs, and workspace IDs;
+- client telemetry IDs, RUM IDs, trace IDs, source-map paths, build IDs, sequence IDs, and generated bundle identifiers;
+- live DOM object dumps, `Window`, `Document`, native `Event`, and DOM element objects logged by reference;
+- framework internal containers and cyclic runtime graph fields such as `__reactContainer`, `alternate`, `stateNode`, `containerInfo`, and `memoizedState`.
+
+## Severity guidance
+
+Severity is assigned by exposed data class, not by the original client-side error.
+
+| Severity | Condition |
+|---|---|
+| High | Cookies, session tokens, auth metadata, or credential-equivalent material appear in raw or redistributed artifacts. |
+| Medium | Account identifiers, relay emails, private page/conversation/tenant route IDs, telemetry IDs, or build IDs appear without cookies. |
+| Low | The artifact is redacted and only structural runtime graph metadata remains. |
+| Informational | Synthetic fixture or documentation-only example with no real user/client values. |
+
+A decorative image or favicon failure is not itself a security incident. It becomes security-relevant when the diagnostic artifact leaks sensitive state or crosses a trust boundary before redaction.
+
+## Expected evidence boundaries
+
+Evidence artifacts MUST NOT include real cookies, real account metadata, real private URLs, or real client session identifiers.
+
+Acceptable evidence includes:
+
+- synthetic unsafe fixture with fake secret-looking markers;
+- redacted safe fixture preserving structure and field classes;
+- bounded summary record;
+- source-card or image-loader failure class without live native event object payload;
+- redaction transform metadata.
+
+## Recommended controls
+
+1. Quarantine raw runtime dumps before indexing or publication.
+2. Redact before pasting into issues, PRs, support tickets, model prompts, notebooks, or telemetry streams.
+3. Reject raw `cookie:`, `client-auth-info`, session IDs, email addresses, and private route IDs in public evidence artifacts.
+4. Prefer bounded diagnostic records over raw native `Event`, `Window`, `Document`, or DOM element objects.
+5. Capture root-cause stacks at assignment, logger, and network boundaries rather than expanding live objects recursively.
+6. Preserve only redacted structural shape for knowledge indexing.
+
+## Detection notes
+
+A simple first-line detector can operate as a lexical guard over diagnostic text. It should flag high-signal tokens and then require redaction review. It does not need to prove exploitability.
+
+Recommended first-line patterns:
+
+```text
+cookie:
+client-auth-info
+session
+sid=
+token
+_puid
+oai-
+__reactContainer
+ownerDocument
+containerInfo
+memoizedState
+Window https://
+HTMLDocument https://
+```
+
+Pattern lists SHOULD be tuned per ingestion surface to avoid blocking legitimate source code references. Public evidence and issue/comment bodies should be stricter than private quarantined evidence stores.
+
+## Knowledge/operations mapping
+
+This finding family maps to the operations-domain profile as:
+
+- `EvidenceArtifact` when a dump or redacted sample enters the evidence plane;
+- `WorkflowState` when the artifact is quarantined, redacted, reviewed, approved, or rejected;
+- `OperationalService` when tied to support, telemetry, incident review, or CI evidence ingestion;
+- `SecurityControl` when implemented as a pre-ingestion redaction gate;
+- `ProvenanceRecord` when recording redaction transforms and lineage.
+
+## Acceptance criteria for implementation
+
+- `ClientRuntimeDumpExposure` profile exists.
+- Safe synthetic example exists.
+- Smoke checks describe high/medium/low severity expectations.
+- Validator rejects missing profile/example/smoke artifacts and required sensitive-field vocabulary omissions.
+- No real cookie, relay email, account ID, private route, or real client telemetry value is committed.
+
+## Non-goals
+
+- Do not store real browser dumps in this repo.
+- Do not create a proprietary telemetry dependency.
+- Do not diagnose a third-party product bug as a SocioProphet runtime defect without source evidence.
+- Do not overfit the detector to a single browser or JavaScript framework.

--- a/examples/client-runtime-dump-exposure-sample.yaml
+++ b/examples/client-runtime-dump-exposure-sample.yaml
@@ -1,0 +1,53 @@
+id: client-runtime-dump-exposure-sample
+version: 0.1.0
+status: synthetic
+finding_family: ClientRuntimeDumpExposure
+samples:
+  unsafe_synthetic:
+    description: >-
+      Synthetic unsafe browser dump excerpt. Values are bracketed placeholders
+      and must not be replaced with real cookies or real user/client identifiers.
+    excerpt: |
+      error { target: img, isTrusted: true, type: "error" }
+      cookie: "[SYNTHETIC_COOKIE_MATERIAL]; [SYNTHETIC_CLIENT_AUTH_INFO]; [SYNTHETIC_PUID]"
+      HTMLDocument https://example.invalid/private-route/[SYNTHETIC_CONVERSATION_ID]
+      __reactContainer$SYNTHETIC: Object { alternate: Object, stateNode: Object }
+      stateNode: Object { containerInfo: HTMLDocument https://example.invalid/private-route/[SYNTHETIC_CONVERSATION_ID] }
+    expected_severity: high
+    expected_controls:
+      - quarantine_raw_dump
+      - redact_before_indexing
+      - reject_public_cookie_material
+  safe_redacted:
+    description: Redacted structural equivalent safe for review and indexing.
+    excerpt: |
+      error { target: img, isTrusted: true, type: "error" }
+      cookie: "[REDACTED_COOKIE_BLOB]"
+      HTMLDocument https://[REDACTED_PRIVATE_ROUTE]
+      __reactContainer$[REDACTED_SUFFIX]: Object { alternate: Object, stateNode: Object }
+      stateNode: Object { containerInfo: HTMLDocument https://[REDACTED_PRIVATE_ROUTE] }
+    expected_severity: low
+    expected_controls:
+      - preserve_redaction_provenance
+      - log_bounded_diagnostic_records
+  bounded_record:
+    description: Preferred bounded diagnostic record shape.
+    record:
+      kind: ClientRuntimeDiagnosticRecord
+      version: "0.1"
+      finding_family: ClientRuntimeDumpExposure
+      event:
+        type: error
+        native_object_logged: false
+      element:
+        tag: IMG
+        is_connected: false
+      redaction:
+        status: applied
+        removed_classes:
+          - cookies
+          - auth_session
+          - identity
+          - private_routes
+          - telemetry
+      severity: low

--- a/profiles/client-runtime-dump-exposure-profile.v0.yaml
+++ b/profiles/client-runtime-dump-exposure-profile.v0.yaml
@@ -1,0 +1,68 @@
+id: client-runtime-dump-exposure-profile
+version: 0.1.0
+status: draft
+finding_family: ClientRuntimeDumpExposure
+related_standard:
+  repo: SocioProphet/socioprophet-standards-knowledge
+  pr: 61
+  path: docs/standards/052-client-runtime-object-dump-forensics.md
+purpose: >-
+  Classify browser/client runtime diagnostic artifacts that expose sensitive
+  client state or cyclic runtime object graphs before redaction.
+severity_model:
+  high:
+    condition: cookies_or_auth_material_present
+    examples:
+      - cookie_field
+      - session_token
+      - client_auth_info
+  medium:
+    condition: identity_or_private_route_or_telemetry_present
+    examples:
+      - relay_email
+      - account_identifier
+      - private_route_id
+      - telemetry_session_id
+      - build_sequence_id
+  low:
+    condition: redacted_structural_runtime_graph_only
+  informational:
+    condition: synthetic_fixture_or_documentation_only
+sensitive_field_classes:
+  cookies:
+    tokens: ["cookie:", "Set-Cookie", "_puid", "sid="]
+  auth_session:
+    tokens: ["auth", "session", "token", "client-auth-info", "did"]
+  identity:
+    tokens: ["email", "relay", "displayName", "avatar", "user_id"]
+  private_routes:
+    tokens: ["conversation_id", "tenant_id", "workspace_id", "route_id"]
+  telemetry:
+    tokens: ["rum", "trace", "source-map", "build", "seq"]
+  runtime_graph:
+    tokens: ["__reactContainer", "ownerDocument", "containerInfo", "memoizedState", "Window", "HTMLDocument"]
+required_controls:
+  - quarantine_raw_dump
+  - redact_before_indexing
+  - reject_public_cookie_material
+  - reject_public_client_auth_info
+  - reject_public_private_route_ids
+  - log_bounded_diagnostic_records
+  - preserve_redaction_provenance
+operations_mapping:
+  evidence_artifact: EvidenceArtifact
+  workflow_state: WorkflowState
+  service: OperationalService
+  control: SecurityControl
+  provenance: ProvenanceRecord
+allowed_evidence:
+  - synthetic_unsafe_fixture
+  - redacted_safe_fixture
+  - bounded_summary_record
+  - redaction_transform_metadata
+disallowed_evidence:
+  - real_browser_cookie
+  - real_auth_session_value
+  - real_relay_email
+  - real_private_conversation_url
+  - real_client_telemetry_session_id

--- a/tests/client-runtime-dump-exposure-smoke.yaml
+++ b/tests/client-runtime-dump-exposure-smoke.yaml
@@ -1,0 +1,45 @@
+id: client-runtime-dump-exposure-smoke
+version: 0.1.0
+status: draft
+checks:
+  - id: finding-family-present
+    description: Profile defines ClientRuntimeDumpExposure.
+    expect_tokens:
+      - ClientRuntimeDumpExposure
+      - finding_family
+  - id: severity-model-present
+    description: Profile distinguishes high, medium, low, and informational severities.
+    expect_tokens:
+      - cookies_or_auth_material_present
+      - identity_or_private_route_or_telemetry_present
+      - redacted_structural_runtime_graph_only
+      - synthetic_fixture_or_documentation_only
+  - id: sensitive-fields-present
+    description: Profile tracks cookie, auth, identity, route, telemetry, and runtime graph classes.
+    expect_tokens:
+      - cookie:
+      - client-auth-info
+      - relay
+      - conversation_id
+      - source-map
+      - __reactContainer
+      - ownerDocument
+      - containerInfo
+  - id: unsafe-synthetic-sample-present
+    description: Example includes synthetic unsafe sample with expected high severity.
+    expect_tokens:
+      - unsafe_synthetic
+      - SYNTHETIC_COOKIE_MATERIAL
+      - expected_severity: high
+  - id: safe-redacted-sample-present
+    description: Example includes redacted safe sample with expected low severity.
+    expect_tokens:
+      - safe_redacted
+      - REDACTED_COOKIE_BLOB
+      - expected_severity: low
+  - id: bounded-record-present
+    description: Example includes preferred bounded diagnostic record shape.
+    expect_tokens:
+      - ClientRuntimeDiagnosticRecord
+      - native_object_logged: false
+      - removed_classes

--- a/tools/validate_client_runtime_dump_exposure.py
+++ b/tools/validate_client_runtime_dump_exposure.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "devops" / "client-runtime-dump-exposure.md"
+PROFILE = ROOT / "profiles" / "client-runtime-dump-exposure-profile.v0.yaml"
+SAMPLE = ROOT / "examples" / "client-runtime-dump-exposure-sample.yaml"
+SMOKE = ROOT / "tests" / "client-runtime-dump-exposure-smoke.yaml"
+
+REQUIRED_FILES = [DOC, PROFILE, SAMPLE, SMOKE]
+
+REQUIRED_DOC_TOKENS = [
+    "ClientRuntimeDumpExposure",
+    "Finding family",
+    "Sensitive field classes",
+    "Severity guidance",
+    "Recommended controls",
+    "cookie:",
+    "client-auth-info",
+    "__reactContainer",
+    "ownerDocument",
+    "containerInfo",
+    "EvidenceArtifact",
+    "SecurityControl",
+    "ProvenanceRecord",
+]
+
+REQUIRED_PROFILE_TOKENS = [
+    "id: client-runtime-dump-exposure-profile",
+    "finding_family: ClientRuntimeDumpExposure",
+    "cookies_or_auth_material_present",
+    "identity_or_private_route_or_telemetry_present",
+    "redacted_structural_runtime_graph_only",
+    "synthetic_fixture_or_documentation_only",
+    "sensitive_field_classes:",
+    "cookies:",
+    "auth_session:",
+    "identity:",
+    "private_routes:",
+    "telemetry:",
+    "runtime_graph:",
+    "quarantine_raw_dump",
+    "redact_before_indexing",
+    "reject_public_cookie_material",
+    "reject_public_client_auth_info",
+    "EvidenceArtifact",
+    "WorkflowState",
+    "OperationalService",
+    "SecurityControl",
+    "ProvenanceRecord",
+]
+
+REQUIRED_SAMPLE_TOKENS = [
+    "id: client-runtime-dump-exposure-sample",
+    "unsafe_synthetic:",
+    "SYNTHETIC_COOKIE_MATERIAL",
+    "SYNTHETIC_CLIENT_AUTH_INFO",
+    "expected_severity: high",
+    "safe_redacted:",
+    "REDACTED_COOKIE_BLOB",
+    "REDACTED_PRIVATE_ROUTE",
+    "expected_severity: low",
+    "bounded_record:",
+    "ClientRuntimeDiagnosticRecord",
+    "native_object_logged: false",
+    "removed_classes:",
+]
+
+REQUIRED_SMOKE_TOKENS = [
+    "finding-family-present",
+    "severity-model-present",
+    "sensitive-fields-present",
+    "unsafe-synthetic-sample-present",
+    "safe-redacted-sample-present",
+    "bounded-record-present",
+    "ClientRuntimeDumpExposure",
+    "cookies_or_auth_material_present",
+    "identity_or_private_route_or_telemetry_present",
+    "redacted_structural_runtime_graph_only",
+    "ClientRuntimeDiagnosticRecord",
+]
+
+# Keep the fixture synthetic. Do not allow obvious real account/contact values or
+# private app-route copies in the committed example pack.
+FORBIDDEN_REGEXES = [
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"),
+    re.compile(r"https://[^\\s]+/(?:private|conversation|tenant|workspace|account)/[^\\s\\]\)]+"),
+]
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def require_tokens(label: str, text: str, tokens: list[str]) -> None:
+    missing = [token for token in tokens if token not in text]
+    if missing:
+        raise ValueError(f"{label} missing required tokens: {missing}")
+
+
+def reject_forbidden(label: str, text: str) -> None:
+    hits = []
+    for regex in FORBIDDEN_REGEXES:
+        hits.extend(match.group(0) for match in regex.finditer(text))
+    if hits:
+        raise ValueError(f"{label} contains forbidden non-synthetic diagnostic tokens: {hits[:3]}")
+
+
+def main() -> int:
+    try:
+        for path in REQUIRED_FILES:
+            if not path.exists():
+                raise FileNotFoundError(path)
+
+        doc_text = DOC.read_text(encoding="utf-8")
+        profile_text = PROFILE.read_text(encoding="utf-8")
+        sample_text = SAMPLE.read_text(encoding="utf-8")
+        smoke_text = SMOKE.read_text(encoding="utf-8")
+        combined = "\n".join([doc_text, profile_text, sample_text, smoke_text])
+
+        require_tokens("doc", doc_text, REQUIRED_DOC_TOKENS)
+        require_tokens("profile", profile_text, REQUIRED_PROFILE_TOKENS)
+        require_tokens("sample", sample_text, REQUIRED_SAMPLE_TOKENS)
+        require_tokens("smoke", smoke_text, REQUIRED_SMOKE_TOKENS)
+        reject_forbidden("client runtime dump exposure artifacts", combined)
+    except FileNotFoundError as exc:
+        return fail(f"missing required file: {exc.args[0]}")
+    except Exception as exc:  # noqa: BLE001 - CLI validator should surface direct error text
+        return fail(str(exc))
+
+    print("OK: validated ClientRuntimeDumpExposure profile, sample, smoke checks, and synthetic-only guard")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the first Global DevSecOps Intelligence tranche for `ClientRuntimeDumpExposure`.

Adds:

- `docs/devops/client-runtime-dump-exposure.md`
- `profiles/client-runtime-dump-exposure-profile.v0.yaml`
- `examples/client-runtime-dump-exposure-sample.yaml`
- `tests/client-runtime-dump-exposure-smoke.yaml`
- `tools/validate_client_runtime_dump_exposure.py`
- `Makefile` target wiring

## Why

Browser console/runtime object dumps can expose sensitive client state while appearing to be harmless debugging objects. The paired Knowledge Context standard has already landed in `SocioProphet/socioprophet-standards-knowledge#61`.

This PR turns that lesson into a GDI finding family with severity, controls, synthetic examples, smoke checks, and a repo-local validator.

## Scope

- GDI detection/profile tranche only
- no real browser dump committed
- no real cookies, account metadata, telemetry IDs, relay emails, or private routes committed
- no runtime ingestion path changed
- no proprietary browser/client/favicons dependency

## Validator behavior

The validator checks:

- finding-family tokens in the doc/profile/sample/smoke files
- severity model coverage for high, medium, low, and informational cases
- sensitive-field classes for cookies, auth/session, identity, private routes, telemetry, and runtime graph fields
- synthetic unsafe sample and redacted safe sample coverage
- bounded `ClientRuntimeDiagnosticRecord` example presence
- synthetic-only guard against obvious real account/contact/private-route patterns

## Validation

Connector-side validation:

```text
compare main...work/client-runtime-dump-exposure-v0-ready
status: ahead
commits ahead: 6
commits behind: 0
changed files: 6
```

Changed files:

```text
Makefile                                                        +5 -2
docs/devops/client-runtime-dump-exposure.md                    +116
examples/client-runtime-dump-exposure-sample.yaml               +53
profiles/client-runtime-dump-exposure-profile.v0.yaml           +68
tests/client-runtime-dump-exposure-smoke.yaml                   +45
tools/validate_client_runtime_dump_exposure.py                 +141
```

Not run in local checkout from this connector session:

```bash
make validate
python3 tools/validate_client_runtime_dump_exposure.py
```

## Related

- Closes #17 after acceptance.
- Builds on SocioProphet/socioprophet-standards-knowledge#61.

## Self-critique

Strong: this is executable, uses synthetic/redacted examples only, preserves the current upstream Makefile generated-footprint target, and keeps the finding scoped to evidence/telemetry handling rather than blaming a vendor/client implementation.

Weak: the validator is token-based, matching current repo style, not a full YAML schema validator. A follow-up can add JSON Schema/YAML shape validation once the repo standardizes richer validation dependencies.