### PR TITLE
Add PI Gate 4 control-plane assessment

### DIFF
--- a/docs/devops/professional-intelligence-gate4-control-plane-assessment.md
+++ b/docs/devops/professional-intelligence-gate4-control-plane-assessment.md
@@ -1,0 +1,103 @@
+# Professional Intelligence OS Gate 4 control-plane assessment
+
+## Status date
+
+2026-05-05
+
+## Current completion readout
+
+- Overall alignment: 74%
+- Runtime implementation: 52%
+- Demo readiness: 80%
+- Cybernetic controls: 58%
+- UI and dashboard integration: 48%
+
+## Assessment summary
+
+The Professional Intelligence OS wave has moved from repo alignment into a locally verifiable Gate 4 demo path. The current control plane is strong enough to demonstrate traceability across platform contracts, playbooks, workspace, policy, obligations, context, search, query, routing, guardrails, Agentplane, model-governance evidence, DelEx status, and dashboard export.
+
+The main remaining risk is not missing architecture. The risk is operationalization: keeping the dashboard state generated from platform verification, promoting verification artifacts to an operator-facing surface, and preventing the expanding repo graph from drifting.
+
+## Green controls
+
+- Platform manifest, contracts, and Professional Intelligence validators are merged.
+- DelEx operating model and status addenda are merged.
+- Playbook validation is merged.
+- Professional Workroom contract and fixture are merged.
+- Policy decision and obligation validation are merged.
+- Context pack, search packet, and query contract validation are merged.
+- Agent Registry authority records are merged.
+- Agentplane workflow bundle is merged.
+- Model Router route decisions are merged.
+- Guardrail Fabric control pack is merged.
+- Model Governance Ledger evidence records are merged.
+- Platform Gate 4 orchestration and local verifier are merged.
+- Platform dashboard-control export is merged.
+- Web dashboard typed fixture and generator are merged.
+- DelEx board rollup is merged.
+
+## Yellow controls
+
+- Dashboard state is exportable and generatable, but not yet automated end-to-end between platform and web.
+- Gate 4 runner verifies references but does not yet execute Agentplane host smoke as part of the same report.
+- Operator-facing artifact surface is not yet present.
+- DelEx board rollup is markdown-level, not yet a machine-updated board.
+- Sociosphere topology is documented, but not yet automatically reading the Gate 4 artifact graph.
+
+## Red controls
+
+No active red blocker remains for the recordable Gate 4 path.
+
+The nearest hard risk is future drift between:
+
+- `prophet-platform` verification output;
+- `mdheller/socioprophet-web` dashboard fixture;
+- DelEx status documents;
+- DelEx boards;
+- Sociosphere topology.
+
+## Control-plane risks
+
+### 1. State divergence
+
+Risk: each repo carries a slightly different percentage or gate status.
+
+Control: treat `prophet-platform` Gate 4 verification output as the generated source for dashboard state and DelEx board rollups.
+
+### 2. Evidence drift
+
+Risk: references exist, but artifacts are not regenerated or checked together.
+
+Control: add an end-to-end verification target that emits a single artifact bundle containing verification report, dashboard-control state, and Agentplane smoke output.
+
+### 3. Board drift
+
+Risk: DelEx board rollup becomes stale while implementation advances.
+
+Control: add a generated board rollup from platform verification output or DelEx register entries.
+
+### 4. Operator invisibility
+
+Risk: artifacts exist in build paths, but operators cannot discover or inspect them.
+
+Control: promote the verification report and dashboard-control state into an operator-facing artifact surface.
+
+### 5. Repo fanout risk
+
+Risk: additional repos begin duplicating ownership of contracts, policy, evidence, or dashboard state.
+
+Control: keep ownership boundaries explicit: Platform owns demo orchestration and verification; DelEx owns operating state; web owns display; Sociosphere owns topology; policy/contract/agent/model repos own their specialized governance surfaces.
+
+## Recommended next actions
+
+1. Extend the platform Gate 4 runner to optionally execute the Agentplane host smoke and include its artifact summary.
+2. Add a generated DelEx board rollup from the platform dashboard-control state.
+3. Add a Sociosphere machine-readable topology view for the Gate 4 artifact graph.
+4. Add an operator artifact surface for Gate 4 reports.
+5. Add a drift check that compares platform export, web fixture, DelEx status, and board rollup percentages.
+
+## Current decision
+
+Professional Intelligence OS is ready to continue Gate 4 execution. It is not yet ready to claim a fully operational production loop.
+
+Gate 4 is locally verifiable. The next maturity target is operational artifact promotion and automated state synchronization.


### PR DESCRIPTION
## Summary

Adds a Professional Intelligence OS Gate 4 control-plane assessment.

Adds:
- `docs/devops/professional-intelligence-gate4-control-plane-assessment.md`

## Current readout

- Overall alignment: ~74%
- Runtime implementation: ~52%
- Demo readiness: ~80%
- Cybernetic controls: ~58%

## Validation

Docs-only assessment.