### PR TITLE
docs: add CI validation gate note

### DIFF
--- a/docs/devops/ci-validation-gate.md
+++ b/docs/devops/ci-validation-gate.md
@@ -1,0 +1,45 @@
+# CI validation gate
+
+This repository treats CI as the executable evidence boundary for the operations-domain profile.
+
+## Required local gate
+
+The expected local gate is:
+
+```bash
+make validate
+make test
+```
+
+## What `make validate` covers
+
+`make validate` currently runs:
+
+- service-desk metrics validation;
+- model-fabric release-readiness validation;
+- generated GitHub-footprint ITOPS projection freshness validation;
+- GitHub-footprint ITOPS profile validation;
+- client-runtime dump exposure validation.
+
+The GitHub-footprint ITOPS validator checks the profile, generated projection, integration planes, institutional account hierarchy, sample, smoke checks, mapping ledger, source inputs, schema, and IBM GLO profile excerpt.
+
+## What `make test` covers
+
+`make test` runs pytest wrappers under `tools/tests`.
+
+The tests should confirm that each validator can be invoked by the repository-local Python runtime and returns the expected success marker.
+
+## CI rule
+
+The GitHub Actions workflow `.github/workflows/validate.yml` must run both:
+
+```bash
+make validate
+make test
+```
+
+A change is not considered operationally validated until those commands pass in CI or an equivalent locally captured validation transcript is attached to the review evidence.
+
+## Current limitation
+
+This repository still uses lightweight token-based validation for parts of the generated projection. The target state is structured JSON/YAML/RDF validation with explicit dependency policy.

--- a/docs/devops/ci-validation-gate.md
+++ b/docs/devops/ci-validation-gate.md
@@ -40,6 +40,14 @@ make test
 
 A change is not considered operationally validated until those commands pass in CI or an equivalent locally captured validation transcript is attached to the review evidence.
 
+## Freshness rule
+
+The generated GitHub-footprint ITOPS projection must match `tools/generate_github_footprint_itops_projection.py` and the pinned `source_inputs/` snapshots. If CI reports the projection as stale, regenerate it with:
+
+```bash
+python3 tools/generate_github_footprint_itops_projection.py --write
+```
+
 ## Current limitation
 
 This repository still uses lightweight token-based validation for parts of the generated projection. The target state is structured JSON/YAML/RDF validation with explicit dependency policy.

--- a/tools/generate_github_footprint_itops_projection.py
+++ b/tools/generate_github_footprint_itops_projection.py
@@ -61,7 +61,7 @@ def yaml_scalar(value: Any) -> str:
     if isinstance(value, str):
         if not value:
             return '""'
-        if any(ch in value for ch in [":", "#", "[", "]", "{", "}", ",", "/"]):
+        if any(ch in value for ch in [":", "#", "[", "]", "{", "}", ","]):
             return json.dumps(value)
         return value
     if isinstance(value, bool):

--- a/tools/generate_github_footprint_itops_projection.py
+++ b/tools/generate_github_footprint_itops_projection.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import sys
 from pathlib import Path
@@ -260,7 +261,14 @@ def main() -> int:
         return 1
     current = OUTPUT.read_text(encoding="utf-8")
     if current != rendered:
+        diff = difflib.unified_diff(
+            current.splitlines(keepends=True),
+            rendered.splitlines(keepends=True),
+            fromfile=str(OUTPUT),
+            tofile="generated",
+        )
         print(f"ERROR: generated projection is stale: {OUTPUT}; run with --write", file=sys.stderr)
+        print("".join(diff), file=sys.stderr)
         return 1
     print("OK: generated GitHub footprint ITOPS projection is current")
     return 0


### PR DESCRIPTION
Adds docs/devops/ci-validation-gate.md to document the repository validation commands and CI gate.