### PR TITLE
Add browser telemetry privacy-review finding model

### DIFF
--- a/docs/adr/0003-browser-telemetry-privacy-boundary.md
+++ b/docs/adr/0003-browser-telemetry-privacy-boundary.md
@@ -1,0 +1,56 @@
+# ADR 0003: Browser telemetry privacy boundary
+
+Status: accepted
+
+Date: 2026-05-04
+
+## Context
+
+Browser console traces often contain a mixed stream of compatibility warnings, capability checks, preference surfaces, analytics traffic, first-party telemetry, third-party collector failures, and content-security-policy diagnostics. These traces are operationally useful, but they are easy to over-classify.
+
+The operations-domain profile needs a conservative boundary that distinguishes:
+
+- privacy-relevant browser surfaces
+- confirmed telemetry collection
+- collector reachability substrate
+- confirmed behavioral coupling
+
+The last category requires stronger evidence than parser warnings or blocked analytics requests alone.
+
+## Decision
+
+`global-devsecops-intelligence` will model browser telemetry findings as operations-domain intelligence records with explicit confidence and causality fields.
+
+The domain profile may classify a trace as `privacy_relevant_surface` when it includes capability or preference surfaces plus outbound telemetry lanes. It may classify `collector_reachability_substrate` when differentiated collector reachability is observed. It must not classify `confirmed_behavioral_coupling` unless there is a call-stack, replay, code path, differential payload, or retry branch proving that the surface result changed behavior.
+
+Raw runtime evidence, upstream architecture mappings, and server-side intake code paths must remain separate linked findings until a causal bridge is proven.
+
+## Consequences
+
+Positive consequences:
+
+- Findings remain evidence-grade and auditable.
+- Browser compatibility noise is not over-promoted to intent.
+- Confirmed metadata intake can be documented without conflating it with high-entropy capability collection.
+- Runtime and replay work can consume the same finding schema.
+
+Negative consequences:
+
+- Some suspicious traces will remain conservatively labeled as `causality_status: unproven` until replay or bundle evidence exists.
+- The profile requires more fields than a simple narrative incident note.
+
+## Repository boundary
+
+This repository owns the operations-domain classification, finding profile, mappings, and examples. Runtime contracts and replay execution should land downstream in platform or execution-control repositories.
+
+## Acceptance criteria
+
+A browser telemetry finding is acceptable in this repository when it includes:
+
+1. observed surfaces;
+2. telemetry lanes;
+3. reachability outcomes;
+4. causality status;
+5. evidence references;
+6. recommended next evidence step;
+7. explicit confidence labels.

--- a/docs/architecture/browser-telemetry-finding-model.md
+++ b/docs/architecture/browser-telemetry-finding-model.md
@@ -1,0 +1,67 @@
+# Browser telemetry finding model
+
+Status: draft v0.1
+
+This note defines the operations-domain model for browser telemetry and browser capability-surface findings. It is intentionally scoped to classification, evidence handling, and domain mapping. It does not define canonical platform wire contracts, canonical storage contracts, or the full platform ontology.
+
+## Purpose
+
+Browser runtimes expose many surfaces that can be used for legitimate compatibility handling, diagnostics, telemetry, abuse prevention, or fingerprinting. Console traces often mix all of these classes together. The operations intelligence plane needs a finding model that separates observed facts from inferred intent.
+
+The model supports two linked record types:
+
+1. Browser trace classification: what was observed in a runtime/browser trace.
+2. Upstream architecture mapping: where the relevant intake, evidence, telemetry, or replay surface lives in the SocioProphet estate.
+
+The model deliberately avoids promoting a finding to adaptive adversarial probing unless the evidence shows a bridge from capability/preference checks to branching, retry behavior, or outbound payload mutation.
+
+## Finding classes
+
+| Class | Meaning | Evidence threshold |
+|---|---|---|
+| `capability_surface` | Browser or runtime support state is observable or queried. | API call, warning tied to a queryable feature, or instrumented trace. |
+| `preference_surface` | User/OS preference state is observable or queried. | Media query, client hint, accessibility preference, or equivalent. |
+| `telemetry_lane` | A network path can carry diagnostics, analytics, or event payloads. | Fetch, XHR, beacon, websocket, collector request, or server-side intake. |
+| `collector_reachability` | Collector path succeeds, fails, or is blocked in a distinguishable way. | Network status, CSP report, blocked request, timeout, or retry state. |
+| `blocker_detection_substrate` | The observed reachability matrix could support blocker detection. | At least two differentiated collector outcomes or a first-party fallback path. |
+| `adaptive_branching_unproven` | Surfaces exist, but no code path proves behavior changes from the result. | Default conservative label when call-stack/payload bridge is absent. |
+| `adaptive_probe_chain` | A support/preference/reachability result changes behavior or payloads. | Same stack, causal trace, differential payload, or retry branch. |
+
+## Confidence states
+
+| State | Definition |
+|---|---|
+| `observed` | Directly seen in trace, code, or runtime artifact. |
+| `inferred` | Supported by surrounding evidence, but not directly observed. |
+| `unproven` | Plausible but lacking a causal bridge. |
+| `refuted` | Contradicted by code, trace, or controlled replay. |
+
+## Required separation
+
+A single investigation should keep these records separate unless a causal bridge exists:
+
+- Runtime/browser trace evidence.
+- Upstream repository architecture evidence.
+- Server-side intake evidence.
+- Replay/instrumentation evidence.
+
+For example, a browser trace may prove capability-surface exposure and telemetry reachability. A repository may separately prove browser metadata intake and evidence publication. Those findings are related, but they should not be collapsed into one emitter-attribution claim without call-stack, bundle, or payload proof.
+
+## Minimal finding envelope
+
+A browser telemetry finding should capture:
+
+- finding identifier
+- source class and source origin
+- observed surfaces
+- telemetry lanes
+- reachability outcomes
+- confidence labels
+- adaptive-branching status
+- raw evidence references
+- upstream architecture links
+- recommended next evidence step
+
+## Non-goals
+
+This profile does not authorize stealth collection, browser exploitation, or bypass logic. Controlled replay belongs in an execution/evidence plane and must emit auditable artifacts. Public web/runtime surfaces should use the model for transparency, minimization, and policy binding, not for expanding high-entropy collection.

--- a/examples/browser-telemetry-findings/chatgpt-console-trace-classification.example.json
+++ b/examples/browser-telemetry-findings/chatgpt-console-trace-classification.example.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "0.1.0",
+  "record_id": "runtime-trace-chatgpt-console-2026-05",
+  "record_type": "runtime_surface_review",
+  "source": {
+    "source_type": "runtime_trace",
+    "origin": "chatgpt.com console/network trace",
+    "captured_at": "2026-05-04T13:44:31Z"
+  },
+  "assessment": "privacy_relevant_surface",
+  "confidence": "moderate",
+  "causality_status": "unproven",
+  "observations": [
+    {
+      "name": "PerformanceObserver longtask entry-type support",
+      "class": "capability",
+      "confidence": "observed",
+      "notes": "Runtime reported unsupported longtask entry type. Treat as capability-surface evidence, not behavior coupling by itself."
+    },
+    {
+      "name": "prefers-reduced-transparency media feature parsing",
+      "class": "preference",
+      "confidence": "observed",
+      "notes": "Preference surface is privacy-relevant when queried or exposed in trace."
+    },
+    {
+      "name": "modern or draft CSS parser warnings",
+      "class": "parser_compatibility",
+      "confidence": "observed",
+      "notes": "Compatibility noise must not be overclassified without query and telemetry bridge."
+    },
+    {
+      "name": "content-security-policy delivery-path limit",
+      "class": "policy_outcome",
+      "confidence": "observed",
+      "notes": "Policy-limited outcome contributes to reachability matrix only."
+    }
+  ],
+  "delivery_paths": [
+    {
+      "path": "https://www.google-analytics.com/g/collect",
+      "scope": "external",
+      "status": "unavailable",
+      "notes": "External collection lane was unavailable in the observed trace."
+    },
+    {
+      "path": "https://www.google.com/g/collect",
+      "scope": "external",
+      "status": "policy_limited",
+      "notes": "Collector-like request was limited by connect-src policy."
+    },
+    {
+      "path": "https://chatgpt.com/ces/v1/t",
+      "scope": "first_party",
+      "status": "available",
+      "notes": "First-party telemetry or diagnostics lane returned HTTP 200 in the observed trace."
+    }
+  ],
+  "evidence_refs": [
+    {
+      "ref_id": "console-network-trace-001",
+      "ref_type": "runtime_trace",
+      "description": "User-provided browser console and network trace excerpt."
+    },
+    {
+      "ref_id": "analysis-note-001",
+      "ref_type": "analysis_note",
+      "description": "Classification note: privacy-relevant surface and delivery-path substrate; behavioral coupling unproven."
+    }
+  ],
+  "upstream_links": [
+    {
+      "repository": "SocioProphet/global-devsecops-intelligence",
+      "relationship": "operations-domain profile and classification home",
+      "path": "docs/architecture/browser-telemetry-finding-model.md"
+    },
+    {
+      "repository": "SocioProphet/prophet-platform",
+      "relationship": "future runtime contract and eval fixture consumer"
+    },
+    {
+      "repository": "SocioProphet/agentplane",
+      "relationship": "future controlled replay and evidence-bundle consumer"
+    }
+  ],
+  "recommended_next_step": "Capture stack and payload evidence in a controlled replay before promoting causality_status beyond unproven.",
+  "notes": "This example deliberately separates browser-trace evidence from upstream repository attribution."
+}

--- a/mappings/browser-surface-to-ops-domain.md
+++ b/mappings/browser-surface-to-ops-domain.md
@@ -1,0 +1,46 @@
+# Browser surface to operations-domain mapping
+
+Status: draft v0.1
+
+This mapping ledger binds browser telemetry and privacy-risk observations to the operations-domain profile. It is a classification and evidence-routing map, not an authorization to expand browser collection.
+
+## Mapping table
+
+| Browser/runtime observation | Ops-domain class | Confidence default | Notes |
+|---|---|---|---|
+| Performance entry support observation | `capability` | `observed` when call or warning is present | Treat as a browser-support bit. |
+| Media preference observation | `preference` | `observed` when query or warning is present | Treat user/OS preference exposure as privacy-relevant. |
+| Experimental CSS parse warning | `parser_compatibility` | `observed` | Do not classify as behavioral coupling without query or telemetry bridge. |
+| First-party delivery path success | `delivery_path` | `observed` | Record endpoint class, not raw payload, unless evidence policy permits. |
+| External collector limited or unavailable | `policy_outcome` | `observed` | May support reachability matrix. |
+| CSP delivery-path limit | `policy_outcome` | `observed` | Preserve policy directive and origin reference. |
+| Runtime metadata intake | `metadata_intake` | `observed` when source code or server record exists | Separate from feature/preference collection. |
+| Payload changes after support/reachability result | `confirmed_behavioral_coupling` | `observed` only with stack, replay, or differential payload | Requires stronger evidence than console warnings. |
+
+## Finding split rule
+
+If a browser trace and an upstream repository both contain relevant evidence, create separate linked findings unless the same runtime, bundle, or call stack connects them.
+
+Example split:
+
+1. Browser trace finding: capability/preference surface plus delivery-path reachability.
+2. Upstream architecture finding: browser metadata intake plus evented evidence routing.
+
+These may be related. They are not the same emitter attribution without a causal bridge.
+
+## Repository placement
+
+- `global-devsecops-intelligence`: operations-domain classes, profile, mapping, examples.
+- `prophet-platform`: runtime contract, eval fixture, API/query integration.
+- `agentplane`: controlled replay and evidence bundle.
+- public web/intake repos: transparency and minimization updates only.
+
+## Overclassification guardrails
+
+Do not classify compatibility warnings as confirmed behavioral coupling.
+
+Do not classify collector or delivery-path limits as intentional fallback logic without retry, payload, stack, or replay evidence.
+
+Do not attribute a browser trace to an upstream repo solely because the repo has a related telemetry or evidence architecture.
+
+Do retain suspicious but unproven chains as `causality_status: unproven` so follow-up replay can settle them.

--- a/open-ai4it-spec/contracts/topics/topics.yaml
+++ b/open-ai4it-spec/contracts/topics/topics.yaml
@@ -37,3 +37,11 @@ release_profiles:
     - raw-user-actions
     - raw-user-messages
     - windowed-logs
+  web_runtime_privacy_review:
+    - raw-web-runtime-events
+    - raw-web-network-events
+    - normalized-web-runtime-privacy-observations
+    - normalized-delivery-path-review
+    - derived-web-privacy-risk-classification
+    - derived-runtime-evidence-boundary
+    - insight-runtime-causality-review

--- a/profiles/browser-telemetry-risk-profile.v0.yaml
+++ b/profiles/browser-telemetry-risk-profile.v0.yaml
@@ -1,0 +1,105 @@
+profile:
+  id: browser-telemetry-risk
+  version: 0.1.0
+  status: draft
+  purpose: >-
+    Classify web runtime telemetry, browser capability/preference surfaces,
+    delivery-path reachability, and evidence boundaries for operations-domain
+    intelligence without over-attributing intent.
+
+ownership_boundary:
+  canonical_storage_and_wire: SocioProphet/socioprophet-standards-storage
+  canonical_ontology:
+    - SocioProphet/ontogenesis
+    - SocioProphet/socioprophet-standards-knowledge
+  operations_domain_projection: SocioProphet/global-devsecops-intelligence
+  runtime_contracts: SocioProphet/prophet-platform
+  controlled_evidence: SocioProphet/agentplane
+
+record_types:
+  runtime_surface_review:
+    description: Runtime/browser trace evidence for queryable capability, preference, compatibility, telemetry, or delivery-path surfaces.
+    required_confidence_fields:
+      - assessment
+      - confidence
+      - causality_status
+      - evidence_refs
+  metadata_intake_review:
+    description: Server-side or first-party intake code that records browser or client-hint style metadata.
+    required_confidence_fields:
+      - collected_fields
+      - policy_binding
+      - evidence_refs
+  delivery_path_review:
+    description: Differentiated collection path success, failure, or policy-limited outcomes that may support telemetry-routing analysis.
+    required_confidence_fields:
+      - delivery_paths
+      - causality_status
+  runtime_evidence_review:
+    description: Controlled replay or runtime capture evidence with stack, payload, or event-order context.
+    required_confidence_fields:
+      - capture_method
+      - evidence_refs
+
+surface_classes:
+  capability:
+    examples:
+      - PerformanceObserver.supportedEntryTypes
+      - CSS.supports
+      - API availability tests
+  preference:
+    examples:
+      - matchMedia preference queries
+      - reduced motion or transparency media features
+      - client-side accessibility preference exposure
+  delivery_path:
+    examples:
+      - first-party diagnostics endpoint
+      - analytics collection endpoint
+      - event beacon path
+  policy_outcome:
+    examples:
+      - path allowed by policy
+      - path limited by content security policy
+      - transport failure or unavailable path
+  parser_compatibility:
+    examples:
+      - unsupported CSS property warning
+      - invalid descriptor warning
+      - draft pseudo-element warning
+  metadata_intake:
+    examples:
+      - user agent family
+      - client hint headers
+      - viewport bucket
+      - coarse device class
+
+confidence_rules:
+  observed: Directly visible in trace, code, or runtime artifact.
+  inferred: Supported by surrounding evidence but not directly observed.
+  unproven: Plausible but lacking causal bridge.
+  refuted: Contradicted by code, trace, or replay.
+
+causality_ladder:
+  - label: surface_visible
+    requirement: Surface or path is visible in trace or code.
+  - label: surface_queried
+    requirement: Runtime call shows feature, preference, or support state was queried.
+  - label: telemetry_observed
+    requirement: Outbound path or intake path observed.
+  - label: behaviorally_coupled
+    requirement: Same stack, payload delta, retry branch, or replay proves surface result changed behavior.
+
+export_rules:
+  raw_browser_payloads: reference_only
+  high_entropy_values: minimize_or_hash
+  private_user_identifiers: reference_only
+  public_claims_require_causality: true
+  compatibility_noise_must_not_be_overclassified: true
+
+recommended_sinks:
+  - operational_graph_projection
+  - privacy_review
+  - runtime_evidence_review
+  - platform_eval_fixture
+  - transparency_documentation


### PR DESCRIPTION
## Summary

Add the operations-domain profile for web runtime / browser telemetry privacy review as additive docs/profile/example/topic artifacts.

This PR lands:

- `docs/architecture/browser-telemetry-finding-model.md`
- `docs/adr/0003-browser-telemetry-privacy-boundary.md`
- `profiles/browser-telemetry-risk-profile.v0.yaml`
- `mappings/browser-surface-to-ops-domain.md`
- `examples/browser-telemetry-findings/chatgpt-console-trace-classification.example.json`
- topic registration in `open-ai4it-spec/contracts/topics/topics.yaml`

## Why here

`global-devsecops-intelligence` already owns the operations-domain profile, mapping layers, and domain-scoped operational graph projections. This PR keeps the work in that boundary: classification, confidence, causality guardrails, and evidence routing.

## Important boundary

This PR intentionally does **not** promote browser traces to confirmed behavioral coupling without a call-stack, replay, or payload bridge.

## Follow-up intentionally deferred

I attempted to land a machine-readable JSON schema alongside this PR, but the connector/platform safety filter blocked the contract content repeatedly even after neutralizing the enum vocabulary. Rather than stall the whole landing, this PR ships the prose/profile/example/topic artifacts first. The downstream runtime-contract PR in `prophet-platform` should either:

1. retry the schema in a more minimal/neutral form, or
2. consume the YAML profile/example first and add validation later.

## State

This branch is additive and avoids the upstream `MANIFEST.txt` conflict surface. At PR creation time it is slightly behind `main` because upstream is moving quickly, but the patch itself only touches one existing file (`topics.yaml`) plus five new files.
