### PR TITLE
fix: unbreak validate (missing pyyaml) and arm the double-escaped exposure guard

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,8 +20,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install test dependencies
-        run: python3 -m pip install --upgrade pip pytest
+      - name: Install pinned dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
 
       - name: Run validators
         run: make validate

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ For a guided tour of the documentation tree, see [`docs/README.md`](docs/README.
 
 ## Validation
 
+Install the pinned dependencies first — this is the same set CI installs, and
+`make validate` fails without it:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
 Run all local validators:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Pinned dependencies for `make validate` and `make test`.
+#
+# tools/validate_operational_exhaust_fusion.py imports yaml; without pyyaml the
+# validate target fails after five validators have already printed OK.
+PyYAML==6.0.3
+
+# Test runner for `make test` (tools/tests).
+pytest==8.4.2

--- a/tools/tests/fixtures/client-runtime-dump-exposure/allowed-synthetic.txt
+++ b/tools/tests/fixtures/client-runtime-dump-exposure/allowed-synthetic.txt
@@ -1,0 +1,14 @@
+# Legitimate synthetic / redacted lines drawn from the committed example pack.
+#
+# Every non-comment, non-blank line MUST NOT be matched by FORBIDDEN_REGEXES.
+# These are the near-misses that a careless tightening of the guard would break:
+# bracketed placeholders, `private-route` (not `/private/`), uppercase
+# CONVERSATION inside a placeholder, and prose that mentions email addresses
+# without containing one.
+cookie: "[SYNTHETIC_COOKIE_MATERIAL]; [SYNTHETIC_CLIENT_AUTH_INFO]; [SYNTHETIC_PUID]"
+HTMLDocument https://example.invalid/private-route/[SYNTHETIC_CONVERSATION_ID]
+stateNode: Object { containerInfo: HTMLDocument https://[REDACTED_PRIVATE_ROUTE] }
+__reactContainer$SYNTHETIC: Object { alternate: Object, stateNode: Object }
+- display names, relay email addresses, account email addresses, avatar URLs, and user identifiers;
+owner_contact: "[REDACTED_ACCOUNT_EMAIL]"
+expected_controls: [quarantine_raw_dump, redact_before_indexing]

--- a/tools/tests/fixtures/client-runtime-dump-exposure/forbidden-positives.txt
+++ b/tools/tests/fixtures/client-runtime-dump-exposure/forbidden-positives.txt
@@ -1,0 +1,13 @@
+# Known positives for tools/validate_client_runtime_dump_exposure.py.
+#
+# Every non-comment, non-blank line MUST be matched by FORBIDDEN_REGEXES and
+# MUST cause the validator to exit non-zero when present in a committed
+# artifact. Domains are RFC 2606 / RFC 6761 reserved names so this fixture
+# never carries a real contact or a real private route.
+#
+# Before the 2026-07 escaping fix all five of these returned False.
+owner_contact: jane.doe@example.com
+reported_by: ops-oncall+alerts@corp.example.org
+dump_source: https://app.example.com/private/session-9f2a1c
+referrer: https://console.example.net/tenant/acme-holdings/workspace/ops-1
+thread_url: https://chat.example.org/conversation/abc123def456

--- a/tools/tests/test_client_runtime_dump_exposure.py
+++ b/tools/tests/test_client_runtime_dump_exposure.py
@@ -1,0 +1,158 @@
+"""Teeth tests for the ClientRuntimeDumpExposure synthetic-only guard.
+
+The guard in tools/validate_client_runtime_dump_exposure.py shipped with
+double-escaped patterns (``\\\\.`` and ``[^\\\\s]``), which require a literal
+backslash inside an email address or URL. It therefore matched nothing while
+still printing ``OK: ... synthetic-only guard``.
+
+These tests pin the guard in both directions:
+  * known positives are matched and are refused end to end;
+  * the committed synthetic example pack still passes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_client_runtime_dump_exposure.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "client-runtime-dump-exposure"
+POSITIVES = FIXTURES / "forbidden-positives.txt"
+ALLOWED = FIXTURES / "allowed-synthetic.txt"
+
+
+def _fixture_lines(path: Path) -> list[str]:
+    lines = [
+        line
+        for raw in path.read_text(encoding="utf-8").splitlines()
+        for line in [raw.strip()]
+        if line and not line.startswith("#")
+    ]
+    assert lines, f"fixture {path} yielded no cases"
+    return lines
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location(
+        "validate_client_runtime_dump_exposure", VALIDATOR
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VALIDATOR_MODULE = _load_validator()
+
+
+def test_validator_passes_on_committed_artifacts() -> None:
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "synthetic-only guard" in result.stdout
+
+
+def test_forbidden_regexes_are_not_double_escaped() -> None:
+    """A doubled backslash disarms the guard silently. Fail loudly instead."""
+    for regex in VALIDATOR_MODULE.FORBIDDEN_REGEXES:
+        assert "\\\\" not in regex.pattern, (
+            "double-escaped pattern requires a literal backslash in the candidate "
+            f"value and can never match: {regex.pattern!r}"
+        )
+
+
+@pytest.mark.parametrize("line", _fixture_lines(POSITIVES))
+def test_known_positives_are_matched(line: str) -> None:
+    hits = [
+        match.group(0)
+        for regex in VALIDATOR_MODULE.FORBIDDEN_REGEXES
+        for match in regex.finditer(line)
+    ]
+    assert hits, f"guard did not match known positive: {line!r}"
+
+
+@pytest.mark.parametrize("line", _fixture_lines(ALLOWED))
+def test_allowed_synthetic_lines_are_not_matched(line: str) -> None:
+    hits = [
+        match.group(0)
+        for regex in VALIDATOR_MODULE.FORBIDDEN_REGEXES
+        for match in regex.finditer(line)
+    ]
+    assert not hits, f"guard flagged a legitimate synthetic line {line!r}: {hits}"
+
+
+def test_reject_forbidden_accepts_the_committed_example_pack() -> None:
+    combined = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            VALIDATOR_MODULE.DOC,
+            VALIDATOR_MODULE.PROFILE,
+            VALIDATOR_MODULE.SAMPLE,
+            VALIDATOR_MODULE.SMOKE,
+        )
+    )
+    VALIDATOR_MODULE.reject_forbidden("committed example pack", combined)
+
+
+def _mirror_artifact_tree(destination: Path) -> Path:
+    """Copy the validator and the four artifacts it reads into a scratch tree.
+
+    The validator resolves its inputs from ``__file__``, so a mirrored tree lets
+    a test poison an artifact without touching the working copy.
+    """
+    for source in (
+        VALIDATOR,
+        VALIDATOR_MODULE.DOC,
+        VALIDATOR_MODULE.PROFILE,
+        VALIDATOR_MODULE.SAMPLE,
+        VALIDATOR_MODULE.SMOKE,
+    ):
+        target = destination / source.relative_to(ROOT)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    return destination / VALIDATOR.relative_to(ROOT)
+
+
+def _run_mirrored(validator_copy: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(validator_copy)],
+        cwd=validator_copy.parents[1],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_mirrored_tree_passes_before_poisoning(tmp_path: Path) -> None:
+    """Control for the poisoning test: the mirror itself must be clean."""
+    result = _run_mirrored(_mirror_artifact_tree(tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("line", _fixture_lines(POSITIVES))
+def test_validator_refuses_poisoned_artifact(line: str, tmp_path: Path) -> None:
+    validator_copy = _mirror_artifact_tree(tmp_path)
+    sample_copy = tmp_path / VALIDATOR_MODULE.SAMPLE.relative_to(ROOT)
+    sample_copy.write_text(
+        sample_copy.read_text(encoding="utf-8") + f"{line}\n", encoding="utf-8"
+    )
+
+    result = _run_mirrored(validator_copy)
+    assert result.returncode != 0, (
+        f"validator accepted a poisoned artifact containing {line!r}\n"
+        + result.stdout
+        + result.stderr
+    )
+    assert "forbidden non-synthetic diagnostic tokens" in result.stderr
+    assert "synthetic-only guard" not in result.stdout

--- a/tools/validate_client_runtime_dump_exposure.py
+++ b/tools/validate_client_runtime_dump_exposure.py
@@ -86,9 +86,16 @@ REQUIRED_SMOKE_TOKENS = [
 
 # Keep the fixture synthetic. Do not allow obvious real account/contact values or
 # private app-route copies in the committed example pack.
+#
+# These patterns are raw strings: write `\.` and `\s`, never `\\.` or `\\s`.
+# A doubled backslash makes the pattern require a literal backslash inside the
+# candidate value, which no email address or URL contains, so the guard silently
+# matches nothing while still printing OK.
+# tools/tests/test_client_runtime_dump_exposure.py locks this down in both
+# directions.
 FORBIDDEN_REGEXES = [
-    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"),
-    re.compile(r"https://[^\\s]+/(?:private|conversation|tenant|workspace|account)/[^\\s\\]\)]+"),
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+    re.compile(r"https://[^\s]+/(?:private|conversation|tenant|workspace|account)/[^\s\]\)]+"),
 ]
 
 


### PR DESCRIPTION
Two independent fixes, each verified before and after.

---

## 1. `main` has been red for 7 weeks

`.github/workflows/validate.yml` installed only `pytest`. PRs #14 / #15 added `tools/validate_operational_exhaust_fusion.py`, which imports `yaml`. There was **no `requirements.txt`** to install, so the dependency never arrived.

`make validate` runs six Python entry points in sequence. Five print `OK`; the sixth exits 1 and `make` returns 2.

Last green push to `main`: 2026-06-11 (run `27319393708`). Every push since has failed — most recently run [`27324782948`](https://github.com/SocioProphet/global-devsecops-intelligence/actions/runs/27324782948), whose log ends:

```
python3 tools/validate_client_runtime_dump_exposure.py
OK: validated ClientRuntimeDumpExposure profile, sample, smoke checks, and synthetic-only guard
python3 tools/validate_operational_exhaust_fusion.py
pyyaml is required: install with `python -m pip install pyyaml`
make: *** [Makefile:22: operational-exhaust-fusion-validate] Error 1
##[error]Process completed with exit code 2.
```

### Fix

Add a pinned `requirements.txt` (`PyYAML==6.0.3`, `pytest==8.4.2`) and install it in the workflow instead of the ad-hoc `pip install pytest`.

### Proof

Reproduced in a venv containing exactly what CI installed — `pip` + `pytest`, no `pyyaml`:

| | `make validate` |
|---|---|
| **before** | five `OK`, then `pyyaml is required: ...` → `make: *** Error 1`, **exit 2** |
| **after** | all six run, including `[OK] operational exhaust fusion mapping validated` → `OK: validate`, **exit 0** |

`make test`: **26 passed**.

---

## 2. A guard that enforced nothing

`tools/validate_client_runtime_dump_exposure.py` guards the committed `ClientRuntimeDumpExposure` example pack against real contact addresses and real private-route URLs. Both `FORBIDDEN_REGEXES` were **double-escaped inside raw strings**:

```python
re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"),
re.compile(r"https://[^\\s]+/(?:private|conversation|tenant|workspace|account)/[^\\s\\]\)]+"),
```

In a raw string `\\` is a **literal backslash**. The email pattern therefore required a backslash between the domain and the TLD, and `[^\\s]` excluded the letter `s` rather than whitespace. No email address or URL contains a backslash — so the guard matched nothing on that axis, while the validator kept printing `OK: ... synthetic-only guard`.

This is a silent-wrong: the check was green because it was inert, not because the fixtures were clean.

### Fix

Single-escape both patterns, and add tests that pin the behaviour **in both directions** with the cases committed as fixtures under `tools/tests/fixtures/client-runtime-dump-exposure/` (RFC 2606 reserved domains only — the fixtures carry no real contact or route).

### Proof — positives now caught

Five known positives, matched by the guard:

| Case | before | after |
|---|---|---|
| `owner_contact: jane.doe@example.com` | `False` | `True` |
| `reported_by: ops-oncall+alerts@corp.example.org` | `False` | `True` |
| `dump_source: https://app.example.com/private/session-9f2a1c` | `False` | `True` |
| `referrer: https://console.example.net/tenant/acme-holdings/workspace/ops-1` | `False` | `True` |
| `thread_url: https://chat.example.org/conversation/abc123def456` | `False` | `True` |

End to end — each positive appended to the committed sample, validator re-run:

- **before:** exit `0`, `OK: validated ... synthetic-only guard`
- **after:** exit `1`, `... contains forbidden non-synthetic diagnostic tokens: [...]`

### Proof — legitimate fixtures still pass

- The fixed patterns produce **zero hits** against all four real committed artifacts (doc, profile, sample, smoke). `make validate` is green.
- Seven near-miss synthetic lines are still accepted: bracketed placeholders, `private-route` rather than `/private/`, uppercase `CONVERSATION` inside a placeholder, and prose that mentions email addresses without containing one.

### Proof — the tests have teeth

Running the new tests against the **pre-fix** validator: **11 of 21 fail**. Against the fixed validator: **all 21 pass**. The suite also asserts at source level that neither pattern contains `\\`, so a re-introduced double-escape fails loudly instead of silently disarming the guard.

---

## Recommendation (no settings changed)

`main` has **no branch protection and no rulesets**:

```
$ gh api repos/SocioProphet/global-devsecops-intelligence/branches/main/protection
{"message":"Branch not protected","status":"404"}

$ gh api repos/SocioProphet/global-devsecops-intelligence/rulesets
[]
```

That is why a red `validate` sat on `main` for seven weeks without blocking anything. Suggested, for a maintainer to apply:

- protect `main`; require the `validate` check to pass before merge;
- require a pull request before merging (no direct pushes to `main`);
- require branches to be up to date with `main` before merging.

Unrelated but noted in passing: `MANIFEST.txt` has drifted — it is missing `tools/validate_operational_exhaust_fusion.py`, `tools/validate_client_runtime_dump_exposure.py`, and the whole `client-runtime-dump-exposure` artifact set. Nothing enforces it, so it is left alone here.

## Verification environment

All local results above come from a venv mirroring the CI step exactly (Python 3.11 target, `pip` + pinned `requirements.txt`). CI results on this PR are whatever the checks below report.
