### PR TITLE
chore: regenerate MANIFEST.txt and enforce it in make validate (both directions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ All notable changes to `global-devsecops-intelligence` are tracked here.
 - Added operational-exhaust and trader-agent fusion profile.
 - Added service-desk metrics and model-fabric release-readiness validators.
 - Added GitHub-footprint ITOPS smoke checks and validator.
+- Regenerated `MANIFEST.txt` from the tracked file list and documented its inclusion rule in the file itself.
+- Added `tools/validate_manifest.py` plus `manifest-validate` / `manifest-write` targets so manifest drift fails `make validate` in both directions.
+- Added `.gitignore` for Python bytecode and pytest caches so local test runs cannot be swept into the tracked tree or the manifest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ If your contribution belongs to an upstream repository, please open the issue or
 4. All PRs require at least one approving review from a maintainer.
 5. CI status checks must pass before merge.
 6. Update `CHANGELOG.md` with a summary of changes under the `[Unreleased]` section.
-7. Update `MANIFEST.txt` if you add or remove files.
+7. Regenerate `MANIFEST.txt` if you add, remove, or rename files: `make manifest-write`. Do not hand-edit it — it is generated from `git ls-files`, and `make validate` fails both when a tracked file is absent from the manifest and when the manifest names a path that is no longer tracked.
 
 ---
 

--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -1,4 +1,33 @@
+# MANIFEST.txt - inventory of every file tracked in this repository.
+#
+# Generated. Do not hand-edit; regenerate with:
+#   make manifest-write     (or: python3 tools/validate_manifest.py --write)
+#
+# The rule below was inferred from the previously hand-maintained contents of
+# this file, then frozen here so it can be enforced rather than merely stated.
+#
+# inclusion rule: every path reported by `git ls-files`, byte-sorted, no exclusions.
+#
+# What that means, and why:
+# - No exclusions. `.github/workflows/validate.yml` was already listed, so
+#   repository-automation files are in scope and are not filtered out.
+# - `third_party/` is IN. All four vendored IBM ITOPS seed files were already
+#   listed. The external-seed boundary is expressed by ADR 0001 and by
+#   `third_party/ibm-itops/UPSTREAM.md`, not by omitting the files from this
+#   inventory: what ships in the tree is what the inventory records.
+# - Byte-sorted (`LC_ALL=C sort`), which is also `git ls-files` order. The
+#   previous list was byte-sorted apart from one hand-edit that hoisted
+#   `docs/README.md` above two adjacent uppercase filenames; that has been
+#   normalised so the inventory is reproducible from the tree.
+# - Blank lines and lines starting with `#` are comments. Every other line is
+#   exactly one repository-relative path.
+#
+# Enforced by tools/validate_manifest.py via `make validate`, which fails both
+# when a tracked file is absent from this list and when this list names a path
+# that is no longer tracked.
+
 .github/workflows/validate.yml
+.gitignore
 CHANGELOG.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
@@ -7,28 +36,49 @@ MANIFEST.txt
 Makefile
 README.md
 SECURITY.md
-docs/README.md
 docs/AGENTIC_SERVICE_DESK_METRICS.md
 docs/MODEL_FABRIC_RELEASE_READINESS.md
+docs/README.md
 docs/adr/0001-ops-domain-profile-and-external-seed-boundary.md
 docs/adr/0002-operational-exhaust-and-trader-agent-fusion-boundary.md
+docs/adr/0003-browser-telemetry-privacy-boundary.md
 docs/architecture/api-interactions-decision.md
+docs/architecture/broker-operational-intelligence-binding.md
+docs/architecture/browser-telemetry-finding-model.md
 docs/architecture/github-footprint-itops-alignment.md
 docs/architecture/institutional-account-hierarchy-itops.md
+docs/architecture/ops-ingestion-and-measurement-plane.md
+docs/architecture/runtime-control-plane-telemetry-alignment.md
+docs/architecture/support-and-premium-support-ai4it-loop.md
+docs/architecture/telemetry-surface-profile.md
+docs/devops/ci-validation-gate.md
+docs/devops/client-runtime-dump-exposure.md
 docs/devops/devops-process-open.md
+docs/devops/metering-anomaly-feedback-pipeline.md
 docs/devops/operational-exhaust-and-trader-agent-fusion.md
+docs/devops/operational-telemetry-integration.md
+docs/devops/professional-intelligence-gate4-control-plane-assessment.md
 docs/vision/ai4it-home-rewrite.md
 examples/agent-service-desk-metrics.example.json
+examples/browser-telemetry-findings/chatgpt-console-trace-classification.example.json
+examples/client-runtime-dump-exposure-sample.yaml
 examples/github-footprint-itops-generated.yaml
 examples/github-footprint-itops-sample.yaml
 examples/model-fabric-release-readiness.example.json
+examples/operational-exhaust/ops-domain-projection.example.json
+mappings/browser-surface-to-ops-domain.md
 mappings/ibm-itops-glo-to-ops-domain.md
+mappings/operational-exhaust-to-ops-domain.v0.yaml
+mappings/ops-telemetry-surface-v1.yaml
+mappings/runtime-control-plane-telemetry-v2.yaml
 open-ai4it-spec/README.md
 open-ai4it-spec/contracts/schemas/entity-output.schema.json
 open-ai4it-spec/contracts/schemas/event-envelope.schema.json
 open-ai4it-spec/contracts/topics/topics.yaml
 open-ai4it-spec/docs/glossary/TERMS.md
 open-ai4it-spec/modules/openentitymap/mapping.schema.json
+profiles/browser-telemetry-risk-profile.v0.yaml
+profiles/client-runtime-dump-exposure-profile.v0.yaml
 profiles/github-footprint-itops-expansion.yaml
 profiles/operational-exhaust-fusion-profile.v0.yaml
 schemas/github-footprint-itops-generated.schema.json
@@ -37,6 +87,7 @@ source_inputs/institutional-account/account-hierarchy.v0.json
 source_inputs/integration-planes/ops-integration-map.v0.json
 source_inputs/ontogenesis/module-map.v0.json
 source_inputs/sociosphere/repository-map.v0.json
+tests/client-runtime-dump-exposure-smoke.yaml
 tests/github-footprint-itops-smoke.yaml
 third_party/ibm-itops/GLO_V1-profile-excerpt.ttl
 third_party/ibm-itops/IMPORT-MANIFEST.v2.json
@@ -44,8 +95,13 @@ third_party/ibm-itops/LICENSE.Apache-2.0
 third_party/ibm-itops/UPSTREAM.md
 tools/generate_github_footprint_itops_projection.py
 tools/tests/test_github_footprint_itops.py
+tools/tests/test_manifest.py
 tools/tests/test_model_fabric_release_readiness.py
+tools/tests/test_operational_exhaust_fusion.py
 tools/tests/test_service_desk_metrics.py
+tools/validate_client_runtime_dump_exposure.py
 tools/validate_github_footprint_itops.py
+tools/validate_manifest.py
 tools/validate_model_fabric_release_readiness.py
+tools/validate_operational_exhaust_fusion.py
 tools/validate_service_desk_metrics.py

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: validate test service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
+.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
 
-validate: service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
+validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
 	@echo "OK: validate"
+
+manifest-validate:
+	python3 tools/validate_manifest.py
+
+manifest-write:
+	python3 tools/validate_manifest.py --write
 
 service-desk-metrics-validate:
 	python3 tools/validate_service_desk_metrics.py

--- a/docs/devops/ci-validation-gate.md
+++ b/docs/devops/ci-validation-gate.md
@@ -15,11 +15,13 @@ make test
 
 `make validate` currently runs:
 
+- file-inventory (`MANIFEST.txt`) validation;
 - service-desk metrics validation;
 - model-fabric release-readiness validation;
 - generated GitHub-footprint ITOPS projection freshness validation;
 - GitHub-footprint ITOPS profile validation;
-- client-runtime dump exposure validation.
+- client-runtime dump exposure validation;
+- operational-exhaust fusion mapping validation.
 
 The GitHub-footprint ITOPS validator checks the profile, generated projection, integration planes, institutional account hierarchy, sample, smoke checks, mapping ledger, source inputs, schema, and IBM GLO profile excerpt.
 
@@ -39,6 +41,18 @@ make test
 ```
 
 A change is not considered operationally validated until those commands pass in CI or an equivalent locally captured validation transcript is attached to the review evidence.
+
+## Inventory rule
+
+`MANIFEST.txt` is the repository's declared file inventory. It is generated, not hand-maintained: the inclusion rule is every path reported by `git ls-files`, byte-sorted, with no exclusions. `third_party/` is inside the inventory — the external-seed boundary is expressed by ADR 0001 and the upstream import record, not by omitting vendored files from the list.
+
+`tools/validate_manifest.py` enforces the inventory in both directions. It fails when a tracked file is absent from `MANIFEST.txt`, and it fails when `MANIFEST.txt` names a path that is no longer tracked. An absent or empty manifest, a manifest that parses to zero paths, and an unreadable tracked-file list are all failures rather than skips, so the check cannot report success on an empty read.
+
+Regenerate after adding, removing, or renaming files:
+
+```bash
+make manifest-write
+```
 
 ## Freshness rule
 

--- a/tools/tests/test_manifest.py
+++ b/tools/tests/test_manifest.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_manifest.py"
+
+# Keep fixture repositories independent of any ambient git configuration so the
+# tracked-file list under test is exactly what the fixture stages.
+GIT_ENV = {**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "GIT_CONFIG_GLOBAL": os.devnull}
+
+
+def run_validator(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(repo / "tools" / "validate_manifest.py"), *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=GIT_ENV,
+    )
+
+
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, env=GIT_ENV)
+
+
+def make_fixture_repo(tmp_path: Path) -> Path:
+    """Build a throwaway git repository carrying a copy of the validator.
+
+    The validator resolves its own root from ``__file__``, so a copy under
+    ``<fixture>/tools/`` validates the fixture rather than this repository. The
+    teeth below can then be exercised for real without mutating the tree.
+    """
+    repo = tmp_path / "fixture"
+    (repo / "tools").mkdir(parents=True)
+    shutil.copy2(VALIDATOR, repo / "tools" / "validate_manifest.py")
+    (repo / "docs").mkdir()
+    (repo / "docs" / "note.md").write_text("note\n", encoding="utf-8")
+    (repo / "kept.md").write_text("kept\n", encoding="utf-8")
+    (repo / "MANIFEST.txt").write_text("", encoding="utf-8")
+    git(repo, "init", "-q")
+    git(repo, "add", "-A")
+    git(repo, "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture", "commit", "-q", "-m", "fixture")
+    assert run_validator(repo, "--write").returncode == 0
+    return repo
+
+
+def manifest_of(repo: Path) -> Path:
+    return repo / "MANIFEST.txt"
+
+
+def test_repository_manifest_matches_tracked_tree() -> None:
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated MANIFEST.txt" in result.stdout
+
+
+def test_fixture_repo_validates_clean(tmp_path: Path) -> None:
+    repo = make_fixture_repo(tmp_path)
+    result = run_validator(repo)
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated MANIFEST.txt" in result.stdout
+
+
+def test_tracked_file_missing_from_manifest_fails(tmp_path: Path) -> None:
+    """Tooth 1: a file lands in the tree and nobody updates the manifest."""
+    repo = make_fixture_repo(tmp_path)
+    (repo / "docs" / "added.md").write_text("added\n", encoding="utf-8")
+    git(repo, "add", "docs/added.md")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "missing 1 tracked file(s)" in result.stderr
+    assert "docs/added.md" in result.stderr
+    assert "OK:" not in result.stdout
+
+
+def test_manifest_entry_for_deleted_file_fails(tmp_path: Path) -> None:
+    """Tooth 2: the manifest keeps naming a path the tree no longer has."""
+    repo = make_fixture_repo(tmp_path)
+    git(repo, "rm", "-q", "docs/note.md")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "no longer tracked" in result.stderr
+    assert "docs/note.md" in result.stderr
+    assert "OK:" not in result.stdout
+
+
+def test_invented_manifest_entry_fails(tmp_path: Path) -> None:
+    """Tooth 2, other shape: a path that was never tracked at all."""
+    repo = make_fixture_repo(tmp_path)
+    manifest = manifest_of(repo)
+    manifest.write_text(manifest.read_text(encoding="utf-8") + "zz-never-existed.md\n", encoding="utf-8")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "no longer tracked" in result.stderr
+    assert "zz-never-existed.md" in result.stderr
+
+
+def test_absent_manifest_fails(tmp_path: Path) -> None:
+    repo = make_fixture_repo(tmp_path)
+    manifest_of(repo).unlink()
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "missing MANIFEST.txt" in result.stderr
+
+
+def test_empty_manifest_fails(tmp_path: Path) -> None:
+    repo = make_fixture_repo(tmp_path)
+    manifest_of(repo).write_text("", encoding="utf-8")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "is empty" in result.stderr
+
+
+def test_header_only_manifest_fails(tmp_path: Path) -> None:
+    """A manifest that parses to zero paths must not read as 'nothing to check'."""
+    repo = make_fixture_repo(tmp_path)
+    manifest = manifest_of(repo)
+    header = [line for line in manifest.read_text(encoding="utf-8").splitlines() if line.startswith("#")]
+    manifest.write_text("\n".join(header) + "\n", encoding="utf-8")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "lists no files" in result.stderr
+
+
+def test_manifest_without_inclusion_rule_fails(tmp_path: Path) -> None:
+    """The declared rule is part of the record and cannot be silently dropped."""
+    repo = make_fixture_repo(tmp_path)
+    manifest = manifest_of(repo)
+    stripped = [
+        line
+        for line in manifest.read_text(encoding="utf-8").splitlines()
+        if not line.startswith("# inclusion rule:")
+    ]
+    manifest.write_text("\n".join(stripped) + "\n", encoding="utf-8")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "no longer declares its inclusion rule" in result.stderr
+
+
+def test_unsorted_manifest_fails(tmp_path: Path) -> None:
+    repo = make_fixture_repo(tmp_path)
+    manifest = manifest_of(repo)
+    lines = manifest.read_text(encoding="utf-8").splitlines()
+    paths = [line for line in lines if line and not line.startswith("#")]
+    comments = [line for line in lines if not line or line.startswith("#")]
+    manifest.write_text("\n".join(comments + list(reversed(paths))) + "\n", encoding="utf-8")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not byte-sorted" in result.stderr
+
+
+def test_unreadable_tracked_list_fails(tmp_path: Path) -> None:
+    """No git metadata means no tracked-file list, which is a failure, not a skip."""
+    repo = make_fixture_repo(tmp_path)
+    shutil.rmtree(repo / ".git")
+
+    result = run_validator(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "could not list tracked files" in result.stderr
+    assert "OK:" not in result.stdout

--- a/tools/validate_manifest.py
+++ b/tools/validate_manifest.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Validate MANIFEST.txt against the repository's tracked file list."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "MANIFEST.txt"
+
+# Sentinel line that must remain in the manifest header. The inclusion rule is
+# part of the record; it must not be quietly deleted while the list survives.
+RULE = "# inclusion rule: every path reported by `git ls-files`, byte-sorted, no exclusions."
+
+HEADER = [
+    "# MANIFEST.txt - inventory of every file tracked in this repository.",
+    "#",
+    "# Generated. Do not hand-edit; regenerate with:",
+    "#   make manifest-write     (or: python3 tools/validate_manifest.py --write)",
+    "#",
+    "# The rule below was inferred from the previously hand-maintained contents of",
+    "# this file, then frozen here so it can be enforced rather than merely stated.",
+    "#",
+    RULE,
+    "#",
+    "# What that means, and why:",
+    "# - No exclusions. `.github/workflows/validate.yml` was already listed, so",
+    "#   repository-automation files are in scope and are not filtered out.",
+    "# - `third_party/` is IN. All four vendored IBM ITOPS seed files were already",
+    "#   listed. The external-seed boundary is expressed by ADR 0001 and by",
+    "#   `third_party/ibm-itops/UPSTREAM.md`, not by omitting the files from this",
+    "#   inventory: what ships in the tree is what the inventory records.",
+    "# - Byte-sorted (`LC_ALL=C sort`), which is also `git ls-files` order. The",
+    "#   previous list was byte-sorted apart from one hand-edit that hoisted",
+    "#   `docs/README.md` above two adjacent uppercase filenames; that has been",
+    "#   normalised so the inventory is reproducible from the tree.",
+    "# - Blank lines and lines starting with `#` are comments. Every other line is",
+    "#   exactly one repository-relative path.",
+    "#",
+    "# Enforced by tools/validate_manifest.py via `make validate`, which fails both",
+    "# when a tracked file is absent from this list and when this list names a path",
+    "# that is no longer tracked.",
+    "",
+]
+
+MAX_REPORTED = 10
+
+
+def fail(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
+
+
+def summarise(paths: list[str]) -> str:
+    shown = ", ".join(paths[:MAX_REPORTED])
+    extra = len(paths) - MAX_REPORTED
+    return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+
+def tracked_files() -> list[str]:
+    """Return the repository's tracked paths, byte-sorted.
+
+    Raises rather than returning an empty list: an unreadable or empty tracked
+    tree is a validation failure, never a silent pass.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RuntimeError(f"could not list tracked files with `git ls-files`: {detail}")
+    paths = [path for path in result.stdout.split("\0") if path]
+    if not paths:
+        raise RuntimeError(
+            "`git ls-files` reported no tracked files; refusing to validate "
+            "MANIFEST.txt against an empty tracked-file list"
+        )
+    return sorted(paths)
+
+
+def render(paths: list[str]) -> str:
+    return "\n".join(HEADER + paths) + "\n"
+
+
+def parse(text: str) -> list[str]:
+    entries = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append(line)
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="regenerate MANIFEST.txt")
+    args = parser.parse_args()
+
+    try:
+        tracked = tracked_files()
+    except RuntimeError as exc:
+        return fail(str(exc))
+
+    if args.write:
+        MANIFEST.write_text(render(tracked), encoding="utf-8")
+        print(f"OK: wrote {MANIFEST.name} with {len(tracked)} tracked files")
+        return 0
+
+    if not MANIFEST.exists():
+        return fail(f"missing {MANIFEST.name}; regenerate with `make manifest-write`")
+    text = MANIFEST.read_text(encoding="utf-8")
+    if not text.strip():
+        return fail(f"{MANIFEST.name} is empty; regenerate with `make manifest-write`")
+    if RULE not in text:
+        return fail(
+            f"{MANIFEST.name} no longer declares its inclusion rule; the header line "
+            f"'{RULE}' must be present"
+        )
+
+    entries = parse(text)
+    if not entries:
+        return fail(
+            f"{MANIFEST.name} lists no files; it must record every tracked path, "
+            f"and this repository tracks {len(tracked)}"
+        )
+
+    problems = []
+
+    duplicates = sorted({entry for entry in entries if entries.count(entry) > 1})
+    if duplicates:
+        problems.append(
+            f"{MANIFEST.name} lists {len(duplicates)} path(s) more than once: {summarise(duplicates)}"
+        )
+
+    missing = sorted(set(tracked) - set(entries))
+    if missing:
+        problems.append(
+            f"{MANIFEST.name} is missing {len(missing)} tracked file(s): {summarise(missing)}"
+        )
+
+    stale = sorted(set(entries) - set(tracked))
+    if stale:
+        problems.append(
+            f"{MANIFEST.name} lists {len(stale)} path(s) that are no longer tracked: "
+            f"{summarise(stale)}"
+        )
+
+    if not problems and entries != sorted(entries):
+        problems.append(f"{MANIFEST.name} is not byte-sorted")
+
+    if not problems and text != render(tracked):
+        problems.append(
+            f"{MANIFEST.name} does not match its generated form (header or spacing drift)"
+        )
+
+    if problems:
+        for problem in problems:
+            fail(problem)
+        print("hint: regenerate with `make manifest-write`", file=sys.stderr)
+        return 1
+
+    print(f"OK: validated {MANIFEST.name} against {len(tracked)} tracked files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_manifest.py
+++ b/tools/validate_manifest.py
@@ -54,6 +54,11 @@ def fail(message: str) -> int:
     return 1
 
 
+def _byte_key(path: str) -> bytes:
+    """Sort key giving LC_ALL=C byte order (git ls-files order), unlike code-point sort."""
+    return path.encode("utf-8")
+
+
 def summarise(paths: list[str]) -> str:
     shown = ", ".join(paths[:MAX_REPORTED])
     extra = len(paths) - MAX_REPORTED
@@ -82,7 +87,9 @@ def tracked_files() -> list[str]:
             "`git ls-files` reported no tracked files; refusing to validate "
             "MANIFEST.txt against an empty tracked-file list"
         )
-    return sorted(paths)
+    # Byte-sort (LC_ALL=C order), NOT Python's default code-point sort: for non-ASCII
+    # UTF-8 paths the two disagree, and the manifest rule promises byte order.
+    return sorted(paths, key=_byte_key)
 
 
 def render(paths: list[str]) -> str:
@@ -110,13 +117,19 @@ def main() -> int:
         return fail(str(exc))
 
     if args.write:
-        MANIFEST.write_text(render(tracked), encoding="utf-8")
+        try:
+            MANIFEST.write_text(render(tracked), encoding="utf-8")
+        except OSError as exc:
+            return fail(f"could not write {MANIFEST.name}: {exc}")
         print(f"OK: wrote {MANIFEST.name} with {len(tracked)} tracked files")
         return 0
 
     if not MANIFEST.exists():
         return fail(f"missing {MANIFEST.name}; regenerate with `make manifest-write`")
-    text = MANIFEST.read_text(encoding="utf-8")
+    try:
+        text = MANIFEST.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return fail(f"could not read {MANIFEST.name}: {exc}")
     if not text.strip():
         return fail(f"{MANIFEST.name} is empty; regenerate with `make manifest-write`")
     if RULE not in text:
@@ -153,7 +166,7 @@ def main() -> int:
             f"{summarise(stale)}"
         )
 
-    if not problems and entries != sorted(entries):
+    if not problems and entries != sorted(entries, key=_byte_key):
         problems.append(f"{MANIFEST.name} is not byte-sorted")
 
     if not problems and text != render(tracked):


### PR DESCRIPTION
`MANIFEST.txt` declares the repository's file inventory. `CONTRIBUTING.md` step 7 asks contributors to keep it current, and ADR 0001 treats it as a record that follow-on work must update. Nothing read it. No validator, no `make` target — the only references are prose. It had drifted **25 files** behind the tracked tree, including four artifacts that a validator already in `make validate` depends on at runtime.

This is the same shape as the exposure guard: a declared record with no enforcement behind it.

## What changed

**1. `MANIFEST.txt` regenerated — 51 entries to 79.**

The inclusion rule is **inferred from the previous contents, not imposed**, and is now recorded in the file's own header:

> every path reported by `git ls-files`, byte-sorted, no exclusions.

Evidence for that reading:

- Every one of the 51 old entries was a tracked file, and there were **zero stale entries** — so the old list was a strict subset of `git ls-files` that had simply fallen behind, not a filtered view.
- **`.github` is IN.** `.github/workflows/validate.yml` was already listed. There is exactly one tracked file under `.github`, and it was in the manifest, so there is no evidence of a `.github` exclusion to preserve.
- **`third_party/` is IN.** All four vendored IBM ITOPS seed files were already listed. The external-seed boundary is expressed by ADR 0001 and `third_party/ibm-itops/UPSTREAM.md` — omitting vendored files from the inventory would state that boundary in the wrong place. What ships in the tree is what the inventory records.
- **Ordering is byte-sorted**, which is also `git ls-files` order. The old list was byte-sorted apart from one hand-edit that hoisted `docs/README.md` above two adjacent uppercase filenames. That is normalised, so the file is reproducible from the tree — the only content change to a pre-existing line.

**2. `tools/validate_manifest.py` + `make manifest-validate`, wired into `make validate`.** Stdlib only, `OK:` on success, `ERROR:` on stderr with exit 1 — matching the existing `tools/validate_*.py` style. `make manifest-write` regenerates.

**3. `tools/tests/test_manifest.py`** — eleven tests in the style of `tools/tests/test_service_desk_metrics.py`. One validates this repository; the rest build a throwaway git repository in `tmp_path` carrying a copy of the validator, so each failure mode is exercised for real without mutating the tree.

**4. `.gitignore`** for Python bytecode and pytest caches. The repo had none, so `make test` leaves untracked `__pycache__` that a contributor running `git add -A` followed by `make manifest-write` would enrol into the inventory.

## Teeth, both directions

A manifest checker that only catches additions is half a checker. Both directions were proved by breaking them and observing red, then restoring.

Tracked file missing from the manifest:

```
$ printf 'drift probe\n' > docs/devops/drift-probe.md && git add docs/devops/drift-probe.md
$ make validate
python3 tools/validate_manifest.py
ERROR: MANIFEST.txt is missing 1 tracked file(s): docs/devops/drift-probe.md
hint: regenerate with `make manifest-write`
make: *** [manifest-validate] Error 1
```

Manifest naming a path that no longer exists:

```
$ git rm -q docs/vision/ai4it-home-rewrite.md
$ make validate
python3 tools/validate_manifest.py
ERROR: MANIFEST.txt lists 1 path(s) that are no longer tracked: docs/vision/ai4it-home-rewrite.md
hint: regenerate with `make manifest-write`
make: *** [manifest-validate] Error 1
```

The test suite was then checked against a half-checker in each direction. Disabling stale detection (additions-only) fails `test_manifest_entry_for_deleted_file_fails` and `test_invented_manifest_entry_fails`; disabling missing detection (removals-only) fails `test_tracked_file_missing_from_manifest_fails`. Both restore to 11 passed.

## Cannot pass on an empty read

An absent manifest, an empty manifest, a manifest that parses to zero paths, and an unreadable or empty tracked-file list are all failures, never skips:

```
-- empty file --   ERROR: MANIFEST.txt is empty; regenerate with `make manifest-write`         rc=1
-- absent file --  ERROR: missing MANIFEST.txt; regenerate with `make manifest-write`          rc=1
-- no git --       ERROR: could not list tracked files with `git ls-files`: fatal: not a git
                          repository (or any of the parent directories): .git                  rc=1
-- zero tracked -- ERROR: `git ls-files` reported no tracked files; refusing to validate
                          MANIFEST.txt against an empty tracked-file list                      rc=1
```

The declared inclusion rule is itself enforced: deleting the `# inclusion rule:` header line fails validation, so the rule cannot be dropped while the list survives.

## Notes for the reviewer

- **`main`'s `validate` workflow has been red since 2026-06-11.** `tools/validate_operational_exhaust_fusion.py` imports `yaml` and the workflow installs only `pytest`. That is #24's subject, not this PR's. Locally `make validate` and `make test` are green here because PyYAML is present in the environment used to develop this change.
- **Merge ordering with #24.** #24 adds `requirements.txt` and three other files. Whichever of the two merges second will need `make manifest-write` re-run — which is the guard working as intended, and is a one-command fix.
- `docs/devops/ci-validation-gate.md` listed five validators while `make validate` ran six; the operational-exhaust entry was missing, so that list is corrected alongside the new manifest entry.
- No behavioural change to any existing validator.
