### PR TITLE
mappings: consume sourceos-spec ResourceContract + Measurement (first real consumer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
+.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate
 
-validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate
+validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate
 	@echo "OK: validate"
 
 manifest-validate:
@@ -26,6 +26,9 @@ client-runtime-dump-exposure-validate:
 
 operational-exhaust-fusion-validate:
 	python3 tools/validate_operational_exhaust_fusion.py
+
+resource-contract-telemetry-validate:
+	python3 tools/validate_resource_contract_telemetry.py
 
 
 test:

--- a/docs/devops/resource-contract-telemetry.md
+++ b/docs/devops/resource-contract-telemetry.md
@@ -1,0 +1,60 @@
+# ResourceContract / Measurement telemetry ingestion
+
+This profile makes `global-devsecops-intelligence` the first real **consumer** of sourceos-spec's
+`Measurement` and `ResourceContract` (SourceOS-Linux/sourceos-spec, merged 2026-07-30).
+
+## Why
+
+Those two schemas exist to make two defects unrepresentable:
+
+- a value nobody measured, reported as instrumented evidence;
+- a limit that observes but never enforces — `Action taken: none`.
+
+Two schemas whose purpose is catching *unused declarations* are worthless if they are themselves
+declared by nobody. This profile is the consumer that closes that gap. It also completes a
+producer → consumer → learning loop:
+
+```text
+producer:  a runner/gate emits a ResourceContract (limit + gate-eligible Measurement of peak)
+consumer:  this plane normalizes it -> TelemetrySignal + EvidenceArtifact  (ops.* topics)
+learning:  a SufficiencyVerdict on ops.learning.feedback.v1 is scored by sociosphere's
+           proof_artifact contract, which feeds back which controls actually have teeth
+```
+
+## The verdict algebra is sociosphere's, not a new one
+
+Gate-eligibility maps onto `sufficiency_type` from `sociosphere/catalog/evidence-contracts.yaml`,
+so the loop speaks one language end to end:
+
+| condition | verdict | meaning |
+|---|---|---|
+| `enforcement != observe` and `fired_count > 0` and peak gate-eligible | **PROVED** | the control has been observed to act on real load |
+| `observedPeak.value > limit.value` and `fired_count == 0` | **VIOLATION** | never-fired control — a counterexample to the claim it is a control |
+| peak not gate-eligible (`source != measured` or `unobserved > 0`) | **INCONCLUSIVE** | sufficiency unestablished; no verdict on the control can be drawn |
+
+The **VIOLATION** row is the load-bearing one. A limit exceeded in production that never once
+enforced is not an absence of news — it is evidence the control is paper. The normalization rule
+`never_fired_control_is_a_violation` forbids dropping it, summarizing it to a healthy counter, or
+downgrading it to INCONCLUSIVE: the exceedance was *measured*, so sufficiency is not the question,
+enforcement is.
+
+## Canonical objects and topics
+
+- `TelemetrySignal` (`signal_class: resource-saturation`) → `ops.telemetry.signals.v1`
+- `EvidenceArtifact` (the ResourceContract as governed, replayable evidence) → `ops.evidence.artifacts.v1`
+- `SufficiencyVerdict` (PROVED / VIOLATION / INCONCLUSIVE) → `ops.learning.feedback.v1`
+
+## Invariants preserved through normalization
+
+- **Gate-eligibility is carried through, never recomputed.** It is a ceiling set by the producer
+  that owns the instrument; a consumer may lower it, never raise it.
+- **Scope is preserved.** A process-scoped and a tenant-scoped limit make different claims;
+  collapsing them hides the fan-out under which a per-process limit is defeated by N cooperating
+  processes each staying under it.
+- **Acting enforcement requires a resolvable negative control**, mirroring the ResourceContract
+  schema's own invariant — a claim to enforce with no demonstration that enforcement can act is
+  inadmissible as evidence.
+
+See `mappings/resource-contract-measurement-telemetry-v1.yaml` and the worked example
+`examples/resource-contract-telemetry.example.json` (a build-runner CPU limit exceeded in
+production that never throttled → VIOLATION).

--- a/examples/resource-contract-telemetry.example.json
+++ b/examples/resource-contract-telemetry.example.json
@@ -1,0 +1,70 @@
+{
+  "_comment": "Worked example for mappings/resource-contract-measurement-telemetry-v1.yaml. The scenario is the real open question about the sovereign build runners: a tenant-scoped CPU limit that was exceeded in production and never once throttled. It shows a ResourceContract normalizing into a TelemetrySignal + EvidenceArtifact + a SufficiencyVerdict of VIOLATION on ops.learning.feedback.v1 — the never-fired control surfaced as a counterexample rather than lost.",
+
+  "source_resource_contract": {
+    "schemaVersion": "0.1.0",
+    "kind": "ResourceContract",
+    "contractId": "runner-tenant-cpu",
+    "resource": "cpu",
+    "limit": { "value": 0.5, "unit": "ratio-of-one-cpu" },
+    "window": "PT180S",
+    "scope": "tenant",
+    "enforcement": "throttle",
+    "negativeControl": "conformance/resource-contract-throttle-fires.md",
+    "firedCount": 0,
+    "observedPeak": {
+      "schemaVersion": "0.1.0",
+      "kind": "Measurement",
+      "label": "peak CPU ratio for the build tenant over the worst observed 180s window",
+      "value": 0.94,
+      "source": "measured",
+      "instrument": "cgroup v2 cpu.stat usage_usec delta, sampled every 10s",
+      "sampling": { "observed": 18, "population": 18, "unit": "10s samples in window" },
+      "unobserved": 0,
+      "gateEligible": true
+    }
+  },
+
+  "normalized": {
+    "TelemetrySignal": {
+      "event_name": "resource.cpu.saturation",
+      "signal_class": "resource-saturation",
+      "source": "sovereign-linux-builder",
+      "ts_ms": 1785424440000,
+      "environment": "sovereign-build",
+      "measurement_value": 0.94,
+      "measurement_source": "measured",
+      "measurement_gate_eligible": true,
+      "measurement_instrument": "cgroup v2 cpu.stat usage_usec delta, sampled every 10s",
+      "resource_contract_id": "runner-tenant-cpu",
+      "runner_tenant_slice_ref": "tenant-build.slice"
+    },
+    "EvidenceArtifact": {
+      "artifact_ref": "resource-contract/runner-tenant-cpu/2026-07-30T14:00:00Z",
+      "artifact_digest": "sha256:PLACEHOLDER-computed-by-producer",
+      "schema_ref": "sourceos-spec:schemas/ResourceContract.json",
+      "produced_by": "sovereign-linux-builder",
+      "observed_at": "2026-07-30T14:00:00Z",
+      "resource": "cpu",
+      "limit_value": 0.5,
+      "limit_unit": "ratio-of-one-cpu",
+      "enforcement": "throttle",
+      "scope": "tenant",
+      "fired_count": 0,
+      "negative_control_ref": "conformance/resource-contract-throttle-fires.md",
+      "observed_peak_ref": "resource.cpu.saturation@1785424440000"
+    },
+    "SufficiencyVerdict": {
+      "verdict": "VIOLATION",
+      "reason": "observed peak 0.94 exceeds the limit 0.5 ratio-of-one-cpu over the same PT180S window, and fired_count is 0 — the tenant CPU limit was breached in production and the declared 'throttle' enforcement never once acted. Per normalization rule never_fired_control_is_a_violation this is a counterexample to the claim that the limit is a control, not the absence of news. The likely cause, per the negative-control procedure, is that cpu.max was written on a slice whose cgroup.procs is empty because the VMM landed under the daemon's hierarchy.",
+      "resource_contract_id": "runner-tenant-cpu",
+      "evidence_artifact_ref": "resource-contract/runner-tenant-cpu/2026-07-30T14:00:00Z"
+    }
+  },
+
+  "counterfactuals": {
+    "_comment": "The same contract under the other two verdicts, to show the mapping is not a rubber stamp for VIOLATION.",
+    "PROVED_if": "fired_count > 0 with a resolvable negativeControl and a gate-eligible peak — the throttle was observed to act on real load.",
+    "INCONCLUSIVE_if": "observedPeak.source were 'assumed' or unobserved > 0 — gateEligible would be false, so sufficiency is unestablished and no verdict on the control can be drawn (an unmeasured peak cannot certify the limit holds)."
+  }
+}

--- a/mappings/resource-contract-measurement-telemetry-v1.yaml
+++ b/mappings/resource-contract-measurement-telemetry-v1.yaml
@@ -1,0 +1,139 @@
+version: v1
+profile: resource-contract-measurement-telemetry
+purpose: >-
+  Make global-devsecops-intelligence the first real CONSUMER of sourceos-spec's Measurement
+  and ResourceContract. A runner or gate that declares a ResourceContract (a limit plus a
+  gate-eligible Measurement of its observed peak) is a resource-saturation telemetry source;
+  this mapping normalizes it into the ops measurement plane's canonical objects, and — the
+  load-bearing part — turns the never-fired-control defect into a learning-feedback VIOLATION
+  instead of letting it disappear.
+#
+# WHY THIS MAPPING EXISTS
+# Measurement.json and ResourceContract.json (SourceOS-Linux/sourceos-spec, merged 2026-07-30)
+# were built to make two defects unrepresentable: a value nobody measured reported as evidence,
+# and a limit that observes but never enforces ("Action taken: none"). Two schemas whose whole
+# purpose is catching unused declarations are worthless if they are themselves declared by
+# nobody. This is the consumer that closes that gap: the ops plane ingests them, and sociosphere
+# (downstream, via ops.learning.feedback.v1) scores them PROVED / VIOLATION / INCONCLUSIVE.
+#
+# The verdict vocabulary is deliberately sociosphere's proof_artifact algebra
+# (catalog/evidence-contracts.yaml), not a new one — gate-eligibility maps onto sufficiency:
+#   Measurement.gateEligible == false                       -> INCONCLUSIVE  (unmeasured/refused)
+#   ResourceContract enforcement acted (firedCount > 0)     -> PROVED        (the control has teeth)
+#   observedPeak.value > limit.value AND firedCount == 0    -> VIOLATION     (never-fired control)
+# The VIOLATION row is the reason the whole estate cares: a limit exceeded in production that
+# never once enforced is not an absence of news, it is a counterexample to the claim that the
+# limit is a control.
+
+source_records:
+  sourceos_spec:
+    resource_contract_ref: schemas/ResourceContract.json      # upstream: SourceOS-Linux/sourceos-spec
+    measurement_ref: schemas/Measurement.json                 # upstream: SourceOS-Linux/sourceos-spec
+    negative_control_ref: conformance/resource-contract-throttle-fires.md
+  prophet_platform:
+    # The producers: runners/gates that emit a ResourceContract. Rolled over prophet-platform,
+    # which is both the runtime that emits these and the deploy target for this plane.
+    runner_tenant_slice_ref: contracts/identity
+  sociosphere:
+    # The downstream learner. Its proof_artifact contract is the verdict target below.
+    evidence_contracts_ref: catalog/evidence-contracts.yaml
+
+canonical_objects:
+  TelemetrySignal:
+    derived_from:
+      - sourceos_spec.measurement_ref
+    signal_class: resource-saturation
+    required_fields:
+      - event_name
+      - signal_class
+      - source
+      - ts_ms
+      - environment
+      - measurement_value
+      - measurement_source        # measured | derived | declared | assumed
+      - measurement_gate_eligible # carried THROUGH, never recomputed downstream
+      - measurement_instrument    # required when measurement_source == measured
+    correlation_fields:
+      - resource_contract_id
+      - runner_tenant_slice_ref
+
+  EvidenceArtifact:
+    # A ResourceContract normalized as a governed, replayable evidence artifact.
+    derived_from:
+      - sourceos_spec.resource_contract_ref
+      - sourceos_spec.negative_control_ref
+    required_fields:
+      - artifact_ref
+      - artifact_digest
+      - schema_ref
+      - produced_by
+      - observed_at
+      - resource
+      - limit_value
+      - limit_unit
+      - enforcement            # observe | throttle | refuse | terminate
+      - scope                  # process | tenant | aggregate
+      - fired_count
+      - negative_control_ref   # MUST resolve; an acting contract with none is not evidence
+      - observed_peak_ref      # the TelemetrySignal above
+
+  SufficiencyVerdict:
+    # The learning-feedback object. Maps the contract onto sociosphere's proof_artifact verdicts
+    # so the loop speaks one algebra end to end.
+    derived_from:
+      - EvidenceArtifact
+      - TelemetrySignal
+    required_fields:
+      - verdict                # PROVED | VIOLATION | INCONCLUSIVE
+      - reason
+      - resource_contract_id
+      - evidence_artifact_ref
+    verdicts:
+      PROVED: >-
+        enforcement != observe AND fired_count > 0 AND the observed peak is gate-eligible —
+        the control has been observed to act on real load.
+      VIOLATION: >-
+        observed_peak.value > limit.value AND fired_count == 0 — the limit was exceeded in
+        production and never once enforced. A never-fired control is a counterexample to the
+        claim that it is a control, not the absence of one.
+      INCONCLUSIVE: >-
+        the observed peak is not gate-eligible (measurement_source != measured, or members were
+        unobserved) — sufficiency is not established, so no verdict on the control can be drawn.
+
+normalization_rules:
+  - id: carry_gate_eligibility_unrecomputed
+    rule: >-
+      measurement_gate_eligible MUST be carried through from the source Measurement and MUST NOT
+      be recomputed or upgraded downstream. Gate-eligibility is a ceiling set by the producer
+      that owns the instrument; a consumer may lower it but never raise it.
+  - id: never_fired_control_is_a_violation
+    rule: >-
+      A ResourceContract whose observed peak exceeds its limit while fired_count is zero MUST
+      normalize to a SufficiencyVerdict of VIOLATION and be published to ops.learning.feedback.v1.
+      It MUST NOT be dropped, summarized to a healthy counter, or downgraded to INCONCLUSIVE —
+      the exceedance was measured, so sufficiency is not the question; enforcement is.
+  - id: unmeasured_peak_is_inconclusive_not_healthy
+    rule: >-
+      A ResourceContract whose observed peak is not gate-eligible MUST normalize to INCONCLUSIVE,
+      never to PROVED. An unmeasured or partially-observed peak cannot certify that a limit holds.
+  - id: acting_enforcement_requires_resolvable_negative_control
+    rule: >-
+      An EvidenceArtifact whose enforcement is not "observe" MUST carry a negative_control_ref
+      that resolves. A claim to enforce with no demonstration that enforcement can act is
+      inadmissible as evidence, mirroring the ResourceContract schema's own invariant.
+  - id: preserve_scope_against_fanout
+    rule: >-
+      scope MUST be preserved on the EvidenceArtifact. A process-scoped limit and a tenant-scoped
+      limit make different claims, and collapsing them hides the fan-out under which a per-process
+      limit is defeated by N cooperating processes each staying under it.
+
+topic_bindings:
+  ops.telemetry.signals.v1:
+    accepts:
+      - TelemetrySignal
+  ops.evidence.artifacts.v1:
+    accepts:
+      - EvidenceArtifact
+  ops.learning.feedback.v1:
+    accepts:
+      - SufficiencyVerdict

--- a/tools/validate_resource_contract_telemetry.py
+++ b/tools/validate_resource_contract_telemetry.py
@@ -15,8 +15,8 @@ does two things a token-count validator does not:
      back under all three input shapes, the rule would be a rubber stamp and this check would be
      proving nothing.
 
-Dependency-light on purpose: the mapping is token-checked with `re` (no pyyaml), and the verdict
-logic runs on the JSON example via stdlib json.
+Dependency-light on purpose: the mapping is token-checked by substring presence (no pyyaml, no
+`re`), and the verdict logic runs on the JSON example via stdlib json.
 """
 
 from __future__ import annotations
@@ -62,9 +62,13 @@ def expected_verdict(*, peak_value, limit_value, fired_count, gate_eligible, enf
       - not gate-eligible wins first: an unmeasured/partial peak cannot certify anything, so no
         verdict on the control can be drawn -> INCONCLUSIVE.
       - then an acting enforcement that has fired -> PROVED: the control was observed to act.
-      - then an exceeded limit that never fired -> VIOLATION: the never-fired control.
-      - otherwise (within limit, or observe-only) there is no counterexample and nothing was
-        proven to act -> INCONCLUSIVE (no news is not proof of teeth).
+      - then an exceeded limit that never fired -> VIOLATION: the never-fired control. This
+        holds in ANY mode, observe included — an observe-mode control must still record the
+        breach, so silence when the limit was exceeded is itself the failure being asserted
+        (see the mapping rule `never_fired_control_is_a_violation`, which carries no observe
+        carve-out either).
+      - otherwise (the limit held, or a control that did fire but — being observe-mode — proves
+        no teeth) there is no counterexample -> INCONCLUSIVE (no news is not proof of teeth).
     """
     if not gate_eligible:
         return "INCONCLUSIVE"

--- a/tools/validate_resource_contract_telemetry.py
+++ b/tools/validate_resource_contract_telemetry.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate the ResourceContract / Measurement telemetry ingestion profile.
+
+This is the first-real-consumer check for sourceos-spec's Measurement + ResourceContract. It
+does two things a token-count validator does not:
+
+  1. It INDEPENDENTLY recomputes the SufficiencyVerdict from the worked example's raw inputs
+     (observed peak vs limit, fired_count, gate-eligibility) and asserts the example's stated
+     verdict matches. A validator that only checked the verdict STRING is present would pass a
+     mislabeled example — the exact "declared, never checked" defect this whole plane exists to
+     catch. So the verdict is derived here, not read.
+
+  2. It MUTATION-TESTS that derivation: flip fired_count and the verdict must move to PROVED;
+     flip the peak's gate-eligibility and it must move to INCONCLUSIVE. If the same verdict came
+     back under all three input shapes, the rule would be a rubber stamp and this check would be
+     proving nothing.
+
+Dependency-light on purpose: the mapping is token-checked with `re` (no pyyaml), and the verdict
+logic runs on the JSON example via stdlib json.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MAPPING = ROOT / "mappings" / "resource-contract-measurement-telemetry-v1.yaml"
+EXAMPLE = ROOT / "examples" / "resource-contract-telemetry.example.json"
+DOC = ROOT / "docs" / "devops" / "resource-contract-telemetry.md"
+
+REQUIRED_FILES = [MAPPING, EXAMPLE, DOC]
+
+# The mapping must DECLARE these — the canonical objects, the three verdicts, the load-bearing
+# normalization rules, and the learning-feedback topic that closes the loop.
+REQUIRED_MAPPING_TOKENS = [
+    "profile: resource-contract-measurement-telemetry",
+    "signal_class: resource-saturation",
+    "TelemetrySignal",
+    "EvidenceArtifact",
+    "SufficiencyVerdict",
+    "measurement_gate_eligible",
+    "PROVED",
+    "VIOLATION",
+    "INCONCLUSIVE",
+    "never_fired_control_is_a_violation",
+    "unmeasured_peak_is_inconclusive_not_healthy",
+    "carry_gate_eligibility_unrecomputed",
+    "acting_enforcement_requires_resolvable_negative_control",
+    "preserve_scope_against_fanout",
+    "ops.telemetry.signals.v1",
+    "ops.evidence.artifacts.v1",
+    "ops.learning.feedback.v1",
+]
+
+
+def expected_verdict(*, peak_value, limit_value, fired_count, gate_eligible, enforcement):
+    """The verdict algebra, reimplemented independently of the mapping prose and the example.
+
+    Precedence matters and is deliberate:
+      - not gate-eligible wins first: an unmeasured/partial peak cannot certify anything, so no
+        verdict on the control can be drawn -> INCONCLUSIVE.
+      - then an acting enforcement that has fired -> PROVED: the control was observed to act.
+      - then an exceeded limit that never fired -> VIOLATION: the never-fired control.
+      - otherwise (within limit, or observe-only) there is no counterexample and nothing was
+        proven to act -> INCONCLUSIVE (no news is not proof of teeth).
+    """
+    if not gate_eligible:
+        return "INCONCLUSIVE"
+    if enforcement != "observe" and fired_count > 0:
+        return "PROVED"
+    if peak_value > limit_value and fired_count == 0:
+        return "VIOLATION"
+    return "INCONCLUSIVE"
+
+
+def main() -> int:
+    failures: list[str] = []
+    checks = 0
+
+    # ── files + mapping tokens ──────────────────────────────────────────────────
+    for f in REQUIRED_FILES:
+        checks += 1
+        if not f.is_file():
+            failures.append(f"missing required file: {f.relative_to(ROOT)}")
+    if failures:
+        for m in failures:
+            print(f"  {m}", file=sys.stderr)
+        return 1
+
+    mapping_text = MAPPING.read_text(encoding="utf-8")
+    for tok in REQUIRED_MAPPING_TOKENS:
+        checks += 1
+        if tok not in mapping_text:
+            failures.append(f"mapping missing required token: {tok!r}")
+    print(f"  {'OK  ' if not failures else 'FAIL'} mapping declares "
+          f"{len(REQUIRED_MAPPING_TOKENS)} required tokens (objects, verdicts, rules, topics)")
+
+    # ── the teeth: derive the example's verdict and check it matches ────────────
+    example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    rc = example["source_resource_contract"]
+    peak = rc["observedPeak"]
+    stated = example["normalized"]["SufficiencyVerdict"]["verdict"]
+
+    got = expected_verdict(
+        peak_value=peak["value"],
+        limit_value=rc["limit"]["value"],
+        fired_count=rc["firedCount"],
+        gate_eligible=peak["gateEligible"],
+        enforcement=rc["enforcement"],
+    )
+    checks += 1
+    if got != stated:
+        failures.append(
+            f"example's stated verdict {stated!r} does not match the verdict derived from its "
+            f"own inputs ({got!r}): peak={peak['value']} limit={rc['limit']['value']} "
+            f"fired={rc['firedCount']} gateEligible={peak['gateEligible']}"
+        )
+        print(f"    FAIL example verdict mislabeled: stated {stated}, derived {got}")
+    else:
+        print(f"    OK   example verdict {stated} is what its own inputs derive "
+              f"(peak {peak['value']} > limit {rc['limit']['value']}, fired {rc['firedCount']})")
+
+    # sanity: the shipped example must actually exercise the load-bearing VIOLATION row, or this
+    # profile's whole reason for existing is untested.
+    checks += 1
+    if stated != "VIOLATION":
+        failures.append(
+            "the shipped example must demonstrate the never-fired-control VIOLATION — that is "
+            f"the load-bearing case; it currently demonstrates {stated}"
+        )
+    else:
+        print("    OK   shipped example exercises the load-bearing VIOLATION row")
+
+    # ── mutation test: the derivation must discriminate, not rubber-stamp ────────
+    print("  mutation test — the verdict moves when the inputs move")
+    base = dict(
+        peak_value=peak["value"], limit_value=rc["limit"]["value"],
+        fired_count=rc["firedCount"], gate_eligible=peak["gateEligible"],
+        enforcement=rc["enforcement"],
+    )
+    mutations = [
+        ("fired_count -> 3 (enforcement acted)", {**base, "fired_count": 3}, "PROVED"),
+        ("gate_eligible -> False (unmeasured peak)", {**base, "gate_eligible": False}, "INCONCLUSIVE"),
+        ("peak within limit, never fired", {**base, "peak_value": 0.10}, "INCONCLUSIVE"),
+    ]
+    for label, kw, want in mutations:
+        checks += 1
+        got_m = expected_verdict(**kw)
+        if got_m != want:
+            failures.append(f"mutation {label}: expected {want}, derived {got_m}")
+        else:
+            print(f"    OK   {label} -> {want}")
+    # if every mutation returned VIOLATION we'd never get here clean — that's the rubber-stamp guard
+
+    if failures:
+        print(f"\n{len(failures)} failure(s) of {checks} checks:", file=sys.stderr)
+        for m in failures:
+            print(f"  {m}", file=sys.stderr)
+        return 1
+
+    print(f"\nOK resource-contract-measurement-telemetry: {checks} checks. The mapping declares "
+          "the loop (telemetry/evidence/learning topics), and the worked example's VIOLATION "
+          "verdict is derived from its own inputs and mutation-tested to discriminate PROVED / "
+          "VIOLATION / INCONCLUSIVE.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes `global-devsecops-intelligence` the **first real consumer** of sourceos-spec's `Measurement` and `ResourceContract` (merged 2026-07-30), and closes a **producer → consumer → learning loop** into the ops measurement plane.

## Why

Those two schemas exist to make two defects unrepresentable: a value nobody measured reported as evidence, and a limit that observes but never enforces (`Action taken: none`). **Two schemas whose purpose is catching unused declarations are worthless if they are themselves declared by nobody.** This is the consumer that closes that gap.

```
producer:  a runner/gate emits a ResourceContract (limit + gate-eligible Measurement of peak)
consumer:  this mapping normalizes it → TelemetrySignal + EvidenceArtifact   (ops.* topics)
learning:  a SufficiencyVerdict → ops.learning.feedback.v1, scored by sociosphere's
           proof_artifact contract, feeding back which controls actually have teeth
```

The learning endpoint (`ops.learning.feedback.v1`) already existed in the plane's `topic_bindings`; this binds the loop into it.

## The verdict algebra is sociosphere's, not a new one

Gate-eligibility maps onto `sufficiency_type` from `sociosphere/catalog/evidence-contracts.yaml`, so the loop speaks one language end to end:

| condition | verdict |
|---|---|
| `enforcement != observe` and `fired_count > 0` and peak gate-eligible | **PROVED** |
| `observedPeak.value > limit.value` and `fired_count == 0` | **VIOLATION** |
| peak not gate-eligible (`source != measured` or `unobserved > 0`) | **INCONCLUSIVE** |

The **VIOLATION** row is load-bearing. A limit exceeded in production that never once enforced is a **counterexample** to the claim it is a control — not the absence of news. Rule `never_fired_control_is_a_violation` forbids dropping it, summarizing it to a healthy counter, or downgrading it to INCONCLUSIVE: the exceedance was *measured*, so sufficiency is not the question, enforcement is.

## The validator has teeth

It does not count tokens and call it a day. It **derives** the worked example's verdict from the raw inputs (peak vs limit, `fired_count`, gate-eligibility) and asserts the stated verdict matches — a token check would pass a *mislabeled* example, the exact declared-never-checked defect this plane exists to catch. It then **mutation-tests** the derivation:

- `fired_count → 3` ⇒ **PROVED**
- `gate_eligible → false` ⇒ **INCONCLUSIVE**
- `peak within limit` ⇒ **INCONCLUSIVE**

25 checks. Wired into `make validate`, verified **by artifact** (the banner appears) and **by negative control** (mislabel the example → `rc=2`; restore → `rc=0`). `make test` pytest suite still green.

## The worked example is a real question, not a toy

A tenant CPU limit on a sovereign build runner, exceeded in production (`peak 0.94 > limit 0.5`) and **never throttled** (`fired_count 0`) → **VIOLATION**. The stated likely cause is the one I could not verify over SSH today: `cpu.max` written on a slice whose `cgroup.procs` is empty because the VMM landed under the daemon's hierarchy. The negative-control procedure in sourceos-spec (`conformance/resource-contract-throttle-fires.md`) is how you'd confirm it on the live runner.

## Follow-ons (not in this PR)

- **sociosphere**: reference this profile's `SufficiencyVerdict` as an upstream input in `catalog/evidence-contracts.yaml`, completing the learning half.
- **prophet-platform**: emit a real `ResourceContract` from a runner (the producer), sourced from live `cgroup` counters.