### PR TITLE
feat: serve GDI as a validation service + buildable image (mesh runtime)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,32 @@
+name: build-image
+# Build + publish the GDI service image to GHCR with an immutable sha- tag
+# (prophet-platform pins that sha in deploy/values/global-devsecops-intelligence.yaml).
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['docs/**', '**/*.md']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push (immutable sha tag)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/socioprophet/global-devsecops-intelligence:sha-${{ github.sha }}
+          provenance: true
+          sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ USER 65532
 EXPOSE 8840
 ENV PORT=8840
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s \
-  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8840/healthz').status==200 else 1)" || exit 1
+  CMD python -c "import os,urllib.request,sys; p=os.environ.get('PORT','8840'); sys.exit(0 if urllib.request.urlopen(f'http://localhost:{p}/healthz', timeout=3).status==200 else 1)" || exit 1
 CMD ["python", "serve.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# GDI — AI4IT ops-intelligence validation profile, served continuously.
+# Runs the repo's real validators (make validate) on a schedule and exposes
+# /healthz + /metrics on :8840 for the prophet-platform deployment. No :latest;
+# CI publishes an immutable sha- tag.
+FROM python:3.12-slim
+
+# `make validate` needs make; keep the layer minimal.
+RUN apt-get update && apt-get install -y --no-install-recommends make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+# non-root to match the deployment securityContext (runAsUser 65532)
+RUN useradd -u 65532 -m gdi && chown -R gdi /app
+USER 65532
+
+EXPOSE 8840
+ENV PORT=8840
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8840/healthz').status==200 else 1)" || exit 1
+CMD ["python", "serve.py"]

--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -26,11 +26,13 @@
 # when a tracked file is absent from this list and when this list names a path
 # that is no longer tracked.
 
+.github/workflows/build-image.yml
 .github/workflows/validate.yml
 .gitignore
 CHANGELOG.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
+Dockerfile
 LICENSE
 MANIFEST.txt
 Makefile
@@ -58,6 +60,7 @@ docs/devops/metering-anomaly-feedback-pipeline.md
 docs/devops/operational-exhaust-and-trader-agent-fusion.md
 docs/devops/operational-telemetry-integration.md
 docs/devops/professional-intelligence-gate4-control-plane-assessment.md
+docs/devops/resource-contract-telemetry.md
 docs/vision/ai4it-home-rewrite.md
 examples/agent-service-desk-metrics.example.json
 examples/browser-telemetry-findings/chatgpt-console-trace-classification.example.json
@@ -66,10 +69,12 @@ examples/github-footprint-itops-generated.yaml
 examples/github-footprint-itops-sample.yaml
 examples/model-fabric-release-readiness.example.json
 examples/operational-exhaust/ops-domain-projection.example.json
+examples/resource-contract-telemetry.example.json
 mappings/browser-surface-to-ops-domain.md
 mappings/ibm-itops-glo-to-ops-domain.md
 mappings/operational-exhaust-to-ops-domain.v0.yaml
 mappings/ops-telemetry-surface-v1.yaml
+mappings/resource-contract-measurement-telemetry-v1.yaml
 mappings/runtime-control-plane-telemetry-v2.yaml
 open-ai4it-spec/README.md
 open-ai4it-spec/contracts/schemas/entity-output.schema.json
@@ -81,7 +86,9 @@ profiles/browser-telemetry-risk-profile.v0.yaml
 profiles/client-runtime-dump-exposure-profile.v0.yaml
 profiles/github-footprint-itops-expansion.yaml
 profiles/operational-exhaust-fusion-profile.v0.yaml
+requirements.txt
 schemas/github-footprint-itops-generated.schema.json
+serve.py
 source_inputs/README.md
 source_inputs/institutional-account/account-hierarchy.v0.json
 source_inputs/integration-planes/ops-integration-map.v0.json
@@ -94,6 +101,9 @@ third_party/ibm-itops/IMPORT-MANIFEST.v2.json
 third_party/ibm-itops/LICENSE.Apache-2.0
 third_party/ibm-itops/UPSTREAM.md
 tools/generate_github_footprint_itops_projection.py
+tools/tests/fixtures/client-runtime-dump-exposure/allowed-synthetic.txt
+tools/tests/fixtures/client-runtime-dump-exposure/forbidden-positives.txt
+tools/tests/test_client_runtime_dump_exposure.py
 tools/tests/test_github_footprint_itops.py
 tools/tests/test_manifest.py
 tools/tests/test_model_fabric_release_readiness.py
@@ -104,4 +114,5 @@ tools/validate_github_footprint_itops.py
 tools/validate_manifest.py
 tools/validate_model_fabric_release_readiness.py
 tools/validate_operational_exhaust_fusion.py
+tools/validate_resource_contract_telemetry.py
 tools/validate_service_desk_metrics.py

--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -108,6 +108,7 @@ tools/tests/test_github_footprint_itops.py
 tools/tests/test_manifest.py
 tools/tests/test_model_fabric_release_readiness.py
 tools/tests/test_operational_exhaust_fusion.py
+tools/tests/test_serve.py
 tools/tests/test_service_desk_metrics.py
 tools/validate_client_runtime_dump_exposure.py
 tools/validate_github_footprint_itops.py

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""GDI service entrypoint — runs the repo's real validators on a schedule and
+exposes health + Prometheus metrics on :$PORT (default 8840), satisfying the
+prophet-platform deployment contract (/healthz, /metrics).
+
+This is deliberately honest: GDI is a validation-profile repo, not a fake HTTP
+API. The service continuously runs `make validate` (manifest, service-desk-
+metrics, model-fabric-release-readiness, github-footprint-itops, client-runtime-
+dump-exposure, operational-exhaust-fusion, resource-contract-telemetry) and
+publishes pass/fail as metrics. The mesh consumer/producer loop (consume
+/telemetry, produce /ops/findings as RCA-claim EventEnvelopes) is layered on top
+of this same validation core — see MESH_* env — and is the next increment.
+
+Stdlib only (keeps requirements.txt to PyYAML+pytest).
+"""
+import os, subprocess, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("PORT", "8840"))
+INTERVAL_S = int(os.environ.get("GDI_VALIDATE_INTERVAL_S", "300"))
+
+_state = {"last_rc": None, "last_ts": 0, "runs": 0, "fails": 0}
+_lock = threading.Lock()
+
+
+def _run_validators() -> None:
+    while True:
+        try:
+            rc = subprocess.run(["make", "validate"], cwd=os.path.dirname(__file__) or ".",
+                                capture_output=True, text=True, timeout=600).returncode
+        except Exception:
+            rc = 2
+        with _lock:
+            _state["last_rc"] = rc
+            _state["last_ts"] = int(time.time())
+            _state["runs"] += 1
+            if rc != 0:
+                _state["fails"] += 1
+        time.sleep(INTERVAL_S)
+
+
+def _metrics() -> str:
+    with _lock:
+        s = dict(_state)
+    ready = 1 if s["last_rc"] == 0 else 0
+    return (
+        "# HELP gdi_up 1 if the last validator run passed.\n"
+        "# TYPE gdi_up gauge\n"
+        f"gdi_up {ready}\n"
+        "# HELP gdi_validate_runs_total total validator runs.\n"
+        "# TYPE gdi_validate_runs_total counter\n"
+        f"gdi_validate_runs_total {s['runs']}\n"
+        "# HELP gdi_validate_failures_total validator runs that failed.\n"
+        "# TYPE gdi_validate_failures_total counter\n"
+        f"gdi_validate_failures_total {s['fails']}\n"
+        "# HELP gdi_last_run_timestamp_seconds unix ts of the last validator run.\n"
+        "# TYPE gdi_last_run_timestamp_seconds gauge\n"
+        f"gdi_last_run_timestamp_seconds {s['last_ts']}\n"
+    )
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # quiet
+        pass
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            # ready once at least one validation run has completed
+            with _lock:
+                ok = _state["last_ts"] > 0
+            body, code = (b'{"status":"ok"}\n' if ok else b'{"status":"starting"}\n'), (200 if ok else 503)
+            self.send_response(code); self.send_header("Content-Type", "application/json")
+            self.end_headers(); self.wfile.write(body)
+        elif self.path == "/metrics":
+            body = _metrics().encode()
+            self.send_response(200); self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.end_headers(); self.wfile.write(body)
+        else:
+            self.send_response(404); self.end_headers()
+
+
+def main() -> None:
+    threading.Thread(target=_run_validators, daemon=True).start()
+    ThreadingHTTPServer(("0.0.0.0", PORT), H).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/serve.py
+++ b/serve.py
@@ -13,11 +13,22 @@ of this same validation core — see MESH_* env — and is the next increment.
 
 Stdlib only (keeps requirements.txt to PyYAML+pytest).
 """
-import os, subprocess, threading, time
+import os, subprocess, sys, threading, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-PORT = int(os.environ.get("PORT", "8840"))
-INTERVAL_S = int(os.environ.get("GDI_VALIDATE_INTERVAL_S", "300"))
+
+def _int_env(key: str, default: int) -> int:
+    """Parse an int env var, falling back to default on a malformed value so a
+    bad PORT/INTERVAL can never crash the service before it serves /healthz."""
+    try:
+        return int(os.environ.get(key, str(default)))
+    except (ValueError, TypeError):
+        sys.stderr.write(f"[gdi] invalid {key}={os.environ.get(key)!r}, using {default}\n")
+        return default
+
+
+PORT = _int_env("PORT", 8840)
+INTERVAL_S = _int_env("GDI_VALIDATE_INTERVAL_S", 300)
 
 _state = {"last_rc": None, "last_ts": 0, "runs": 0, "fails": 0}
 _lock = threading.Lock()
@@ -26,10 +37,15 @@ _lock = threading.Lock()
 def _run_validators() -> None:
     while True:
         try:
-            rc = subprocess.run(["make", "validate"], cwd=os.path.dirname(__file__) or ".",
-                                capture_output=True, text=True, timeout=600).returncode
-        except Exception:
+            r = subprocess.run(["make", "validate"], cwd=os.path.dirname(__file__) or ".",
+                               capture_output=True, text=True, timeout=600)
+            rc = r.returncode
+            if rc != 0:  # emit detail so a failed run is debuggable from pod logs
+                sys.stderr.write(f"[gdi] make validate failed rc={rc}\n"
+                                 f"{r.stdout[-4000:]}\n{r.stderr[-2000:]}\n")
+        except Exception as e:
             rc = 2
+            sys.stderr.write(f"[gdi] make validate errored: {e}\n")
         with _lock:
             _state["last_rc"] = rc
             _state["last_ts"] = int(time.time())

--- a/tools/tests/test_serve.py
+++ b/tools/tests/test_serve.py
@@ -1,0 +1,40 @@
+"""Tests for the serve.py runtime: crash-safe env parsing + Prometheus
+exposition format + readiness logic. Loads serve.py by path (repo root)."""
+import importlib.util
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_spec = importlib.util.spec_from_file_location("gdi_serve", os.path.join(ROOT, "serve.py"))
+serve = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(serve)
+
+
+def test_int_env_falls_back_on_malformed():
+    os.environ["GDI_TEST_BAD"] = "not-an-int"
+    assert serve._int_env("GDI_TEST_BAD", 7) == 7
+    os.environ["GDI_TEST_OK"] = "42"
+    assert serve._int_env("GDI_TEST_OK", 7) == 42
+    assert serve._int_env("GDI_TEST_ABSENT", 9) == 9
+
+
+def test_metrics_are_valid_prometheus_exposition():
+    with serve._lock:
+        serve._state.update(last_rc=0, last_ts=123, runs=5, fails=1)
+    m = serve._metrics()
+    assert "gdi_up 1" in m
+    assert "gdi_validate_runs_total 5" in m
+    assert "gdi_validate_failures_total 1" in m
+    # every non-comment line must parse as "metric_name <float>"
+    for line in m.strip().splitlines():
+        if line and not line.startswith("#"):
+            name, value = line.split()
+            assert name and float(value) is not None
+
+
+def test_gdi_up_reflects_last_rc():
+    with serve._lock:
+        serve._state.update(last_rc=1)
+    assert "gdi_up 0" in serve._metrics()
+    with serve._lock:
+        serve._state.update(last_rc=0)
+    assert "gdi_up 1" in serve._metrics()


### PR DESCRIPTION
Makes GDI runnable as the DevSecOps Workroom runtime / mesh consumer.

- **serve.py** — runs the repo's real validators (`make validate`) on a schedule; exposes `/healthz` + `/metrics` on :8840. `gdi_up`, `gdi_validate_runs_total`, `gdi_validate_failures_total` (honest — reflects actual validation status). Stdlib only.
- **Dockerfile** — python:3.12-slim, non-root (65532), no `:latest`.
- **build-image.yml** — publishes immutable `ghcr…:sha-<sha>` with provenance + SBOM; prophet-platform pins that sha in `deploy/values`.

Verified locally: `/healthz` 200 after first validate cycle, `/metrics` served, validator loop increments. Mesh consume/produce (EventEnvelope on /telemetry→/ops) layers on this core next.