### PR TITLE
fix(ci): add setup-buildx-action to fix build-image attestation failure

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        # Creates a docker-container builder (the default for this action).
+        # Required because provenance/SBOM attestations below are not
+        # supported by the plain `docker` driver you get without this step:
+        # "Attestation is not supported for the docker driver."
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Problem

`build-image` has failed on every run on `main` since #27 landed, including today's push (run [30738500561](https://github.com/SocioProphet/global-devsecops-intelligence/actions/runs/30738500561)), with:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/attestations/
##[error]buildx failed with: Learn more at https://docs.docker.com/go/attestations/
```

## Root cause

`.github/workflows/build-image.yml`'s `docker/build-push-action@v6` step sets `provenance: true` and `sbom: true`, but the job never runs `docker/setup-buildx-action`. Without it, buildx uses the default `docker` driver bound to the runner's daemon context — and per Docker's own docs, [provenance/SBOM attestations require the `docker-container` driver (or the containerd image store)](https://docs.docker.com/build/ci/github-actions/attestations/); the plain `docker` driver can't produce them.

`validate.yml` was also checked and has no `build-push-action` step, so it isn't affected. `build-image.yml` is the only workflow in the repo that builds/pushes an image.

## Fix

Add a `docker/setup-buildx-action@v3` step before the build step. This creates a `docker-container` builder (its default behavior), which supports attestations, so the existing `provenance: true` / `sbom: true` config now works instead of failing.

Kept provenance/SBOM enabled rather than disabling them: this image's sha tag is consumed and pinned by prophet-platform's deploy manifests, so the supply-chain attestations are worth keeping rather than dropping to route around the error.

## Verification

- The failure was confirmed directly from the real failed job log (`gh run view 30738500561 --log-failed`), reproduced above verbatim.
- Docker/GitHub CLI isn't available in the environment I fixed this from, so I installed `docker` + `docker-buildx` (Homebrew) and pointed `DOCKER_HOST` at a local Podman machine's API socket to get a real buildx toolchain. Using a `docker-container`-driver builder (the same kind `setup-buildx-action@v3` creates), I ran the equivalent of this workflow's build command:

  ```
  docker buildx build --attest type=provenance --attest type=sbom,disabled=false --tag test:attest -o type=oci,dest=/tmp/out.tar .
  ```

  This completed successfully, including `exporting attestation manifest ... done` — confirming attestations work fine once the build runs under a `docker-container` builder, which is exactly what this PR adds.
- `.github/workflows/build-image.yml` YAML was validated with `python3 -c "import yaml; yaml.safe_load(open(...))"` — parses cleanly.

## Change

```yaml
      - uses: actions/checkout@v4
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
      - name: Log in to GHCR
        ...
```