### PR TITLE
feat(ingest): register MeshRush ops-intelligence events (GDI-1 consumer side)

### DIFF
--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -67,6 +67,8 @@ examples/browser-telemetry-findings/chatgpt-console-trace-classification.example
 examples/client-runtime-dump-exposure-sample.yaml
 examples/github-footprint-itops-generated.yaml
 examples/github-footprint-itops-sample.yaml
+examples/meshrush-cairnpath-walk.event.json
+examples/meshrush-slot-fill.event.json
 examples/model-fabric-release-readiness.example.json
 examples/operational-exhaust/ops-domain-projection.example.json
 examples/resource-contract-telemetry.example.json
@@ -113,6 +115,7 @@ tools/tests/test_service_desk_metrics.py
 tools/validate_client_runtime_dump_exposure.py
 tools/validate_github_footprint_itops.py
 tools/validate_manifest.py
+tools/validate_meshrush_events.py
 tools/validate_model_fabric_release_readiness.py
 tools/validate_operational_exhaust_fusion.py
 tools/validate_resource_contract_telemetry.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate
+.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate
 
-validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate
+validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate
 	@echo "OK: validate"
 
 manifest-validate:
@@ -29,6 +29,9 @@ operational-exhaust-fusion-validate:
 
 resource-contract-telemetry-validate:
 	python3 tools/validate_resource_contract_telemetry.py
+
+meshrush-events-validate:
+	python3 tools/validate_meshrush_events.py
 
 
 test:

--- a/examples/meshrush-cairnpath-walk.event.json
+++ b/examples/meshrush-cairnpath-walk.event.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1754100000000,
+  "timestamp": 1785628800000,
   "utc_timestamp": "2026-08-02T00:00:00.000Z",
   "type": "meshrush_cairnpath_walk",
   "data_name": "cairnpath_walk",
@@ -8,7 +8,10 @@
     "dataset_ref": "meshrush:diffusion",
     "digest": "blake2b:0000000000000000000000000000000000000000000000000000000000000000",
     "n_steps": 2,
-    "opcodes": ["retrieve", "retrieve"],
+    "opcodes": [
+      "retrieve",
+      "retrieve"
+    ],
     "materialized_steps": 1
   }
 }

--- a/examples/meshrush-cairnpath-walk.event.json
+++ b/examples/meshrush-cairnpath-walk.event.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": 1754100000000,
+  "utc_timestamp": "2026-08-02T00:00:00.000Z",
+  "type": "meshrush_cairnpath_walk",
+  "data_name": "cairnpath_walk",
+  "data": {
+    "line_id": "slotfill",
+    "dataset_ref": "meshrush:diffusion",
+    "digest": "blake2b:0000000000000000000000000000000000000000000000000000000000000000",
+    "n_steps": 2,
+    "opcodes": ["retrieve", "retrieve"],
+    "materialized_steps": 1
+  }
+}

--- a/examples/meshrush-slot-fill.event.json
+++ b/examples/meshrush-slot-fill.event.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1754100000000,
+  "timestamp": 1785628800000,
   "utc_timestamp": "2026-08-02T00:00:00.000Z",
   "type": "meshrush_slot_fill",
   "data_name": "slot_fill",
@@ -7,10 +7,20 @@
     "n_filled": 1,
     "n_refused": 1,
     "fills": [
-      {"slot": "competitors", "artifact_id": "artA", "entity_ref": "meshrush:artifact:artA", "epistemic": "bounded", "score": 0.91}
+      {
+        "slot": "competitors",
+        "artifact_id": "artA",
+        "entity_ref": "meshrush:artifact:artA",
+        "epistemic": "bounded",
+        "score": 0.91
+      }
     ],
     "refused": [
-      {"slot": "pricing", "reason": "no artifact meets epistemic floor 'proved'; refused rather than back-filled with a weaker artifact", "best_available_epistemic": "bounded"}
+      {
+        "slot": "pricing",
+        "reason": "no artifact meets epistemic floor 'proved'; refused rather than back-filled with a weaker artifact",
+        "best_available_epistemic": "bounded"
+      }
     ]
   }
 }

--- a/examples/meshrush-slot-fill.event.json
+++ b/examples/meshrush-slot-fill.event.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": 1754100000000,
+  "utc_timestamp": "2026-08-02T00:00:00.000Z",
+  "type": "meshrush_slot_fill",
+  "data_name": "slot_fill",
+  "data": {
+    "n_filled": 1,
+    "n_refused": 1,
+    "fills": [
+      {"slot": "competitors", "artifact_id": "artA", "entity_ref": "meshrush:artifact:artA", "epistemic": "bounded", "score": 0.91}
+    ],
+    "refused": [
+      {"slot": "pricing", "reason": "no artifact meets epistemic floor 'proved'; refused rather than back-filled with a weaker artifact", "best_available_epistemic": "bounded"}
+    ]
+  }
+}

--- a/open-ai4it-spec/contracts/topics/topics.yaml
+++ b/open-ai4it-spec/contracts/topics/topics.yaml
@@ -23,6 +23,7 @@ release_profiles:
     - derived-log-clustering
     - derived-log-explanation
     - derived-log-story-localization
+    - derived-meshrush-slot-fill
     - derived-stories
     - normalized-alerts
     - normalized-incidents
@@ -31,6 +32,7 @@ release_profiles:
     - normalized-metrics
     - raw-k8s-configs
     - raw-logdna-logs
+    - raw-meshrush-cairnpath-walk
     - raw-pagerduty-alerts
     - raw-servicenow-incidents
     - raw-sysdig-metrics

--- a/tools/validate_meshrush_events.py
+++ b/tools/validate_meshrush_events.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate MeshRush-emitted AI4IT events against GDI's event-envelope + topic registry.
+
+MeshRush is a signal source for GDI (ops-intelligence normalizer/query plane): it
+emits cairnpath walks and slot-fill results (with epistemic level + refusals) as
+AI4IT events. This validator makes GDI's ingest contract for those events explicit
+and enforced — it runs in ``make validate``, which CI runs, every image build runs,
+and ``serve.py`` runs continuously, so the MeshRush event class is auto-checked on
+every build and rollout.
+
+Dependency-light on purpose (matches the other GDI validators): stdlib only, no
+jsonschema/pyyaml. It (1) enforces the event-envelope's required fields, snake_case
+``type`` pattern, and additionalProperties:false against each fixture; (2) checks
+each event ``type`` is a registered MeshRush topic in topics.yaml (token presence);
+and (3) recomputes the slot-fill counts so a mislabeled example cannot pass.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "open-ai4it-spec/contracts/schemas/event-envelope.schema.json"
+TOPICS = ROOT / "open-ai4it-spec/contracts/topics/topics.yaml"
+EVENTS = [
+    ROOT / "examples/meshrush-slot-fill.event.json",
+    ROOT / "examples/meshrush-cairnpath-walk.event.json",
+]
+# MeshRush event type -> its registered topic string (must appear in topics.yaml).
+MESHRUSH_TOPICS = {
+    "meshrush_slot_fill": "derived-meshrush-slot-fill",
+    "meshrush_cairnpath_walk": "raw-meshrush-cairnpath-walk",
+}
+_TYPE_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def _fail(msg: str) -> None:
+    raise ValueError(msg)
+
+
+def _load(p: Path):
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _validate_envelope(event: dict, schema: dict, label: str) -> None:
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    for key in required:
+        if key not in event:
+            _fail(f"{label}: missing required '{key}'")
+    if schema.get("additionalProperties") is False:
+        extra = sorted(set(event) - set(props))
+        if extra:
+            _fail(f"{label}: unexpected fields {extra} (additionalProperties:false)")
+    if not isinstance(event["timestamp"], int) or isinstance(event["timestamp"], bool):
+        _fail(f"{label}: timestamp must be an integer (POSIX ms)")
+    if not isinstance(event["utc_timestamp"], str) or not event["utc_timestamp"]:
+        _fail(f"{label}: utc_timestamp must be a non-empty string")
+    if not _TYPE_RE.fullmatch(event["type"]):
+        _fail(f"{label}: type {event['type']!r} must match ^[a-z0-9_]+$")
+
+
+def main() -> int:
+    try:
+        schema = _load(SCHEMA)
+        topics_text = TOPICS.read_text(encoding="utf-8")
+        for path in EVENTS:
+            event = _load(path)
+            label = path.name
+            _validate_envelope(event, schema, label)
+
+            etype = event["type"]
+            if etype not in MESHRUSH_TOPICS:
+                _fail(f"{label}: unknown MeshRush event type {etype!r}")
+            topic = MESHRUSH_TOPICS[etype]
+            if topic not in topics_text:
+                _fail(f"{label}: topic {topic!r} for type {etype!r} not registered in topics.yaml")
+
+            # Semantic check: a slot-fill's stated counts must match its arrays
+            # (a mislabeled example must not pass — the estate's declared-not-checked rule).
+            if etype == "meshrush_slot_fill":
+                d = event.get("data", {})
+                if d.get("n_filled") != len(d.get("fills", [])):
+                    _fail(f"{label}: n_filled != len(fills)")
+                if d.get("n_refused") != len(d.get("refused", [])):
+                    _fail(f"{label}: n_refused != len(refused)")
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: MeshRush event ingest validated ({len(EVENTS)} events, {len(MESHRUSH_TOPICS)} topics)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_meshrush_events.py
+++ b/tools/validate_meshrush_events.py
@@ -16,6 +16,7 @@ and (3) recomputes the slot-fill counts so a mislabeled example cannot pass.
 """
 from __future__ import annotations
 
+import datetime
 import json
 import re
 import sys
@@ -60,6 +61,14 @@ def _validate_envelope(event: dict, schema: dict, label: str) -> None:
         _fail(f"{label}: utc_timestamp must be a non-empty string")
     if not _TYPE_RE.fullmatch(event["type"]):
         _fail(f"{label}: type {event['type']!r} must match ^[a-z0-9_]+$")
+    # Cross-check the two time fields agree (internally consistent event time).
+    try:
+        dt = datetime.datetime.fromisoformat(event["utc_timestamp"].replace("Z", "+00:00"))
+    except ValueError:
+        _fail(f"{label}: utc_timestamp is not an RFC3339/ISO-8601 date-time")
+    expected_ms = int(dt.timestamp() * 1000)
+    if abs(expected_ms - event["timestamp"]) > 1000:
+        _fail(f"{label}: timestamp {event['timestamp']} disagrees with utc_timestamp ({expected_ms})")
 
 
 def main() -> int:
@@ -75,18 +84,22 @@ def main() -> int:
             if etype not in MESHRUSH_TOPICS:
                 _fail(f"{label}: unknown MeshRush event type {etype!r}")
             topic = MESHRUSH_TOPICS[etype]
-            if topic not in topics_text:
-                _fail(f"{label}: topic {topic!r} for type {etype!r} not registered in topics.yaml")
+            # Match a real YAML list entry, not any substring (avoid comment false-positives).
+            if not re.search(rf"^\s*-\s*{re.escape(topic)}\s*$", topics_text, re.MULTILINE):
+                _fail(f"{label}: topic {topic!r} for type {etype!r} not registered as a topics.yaml list entry")
 
             # Semantic check: a slot-fill's stated counts must match its arrays
             # (a mislabeled example must not pass — the estate's declared-not-checked rule).
             if etype == "meshrush_slot_fill":
                 d = event.get("data", {})
-                if d.get("n_filled") != len(d.get("fills", [])):
+                fills, refused = d.get("fills"), d.get("refused")
+                if not isinstance(fills, list) or not isinstance(refused, list):
+                    _fail(f"{label}: data.fills and data.refused must be lists")
+                if d.get("n_filled") != len(fills):
                     _fail(f"{label}: n_filled != len(fills)")
-                if d.get("n_refused") != len(d.get("refused", [])):
+                if d.get("n_refused") != len(refused):
                     _fail(f"{label}: n_refused != len(refused)")
-    except ValueError as exc:
+    except (ValueError, OSError, TypeError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
     print(f"OK: MeshRush event ingest validated ({len(EVENTS)} events, {len(MESHRUSH_TOPICS)} topics)")


### PR DESCRIPTION
## What
The GDI consumer side of **GDI-1**: register MeshRush's operational signals so GDI normalizes and can query them, and so the contract is **auto-validated on every build and rollout**.

MeshRush ([meshrush #22](https://github.com/SocioProphet/meshrush/pull/22)) emits cairnpath walks + slot-fill results (carrying **epistemic level + refusals** — the governance signal) as AI4IT events.

- **topics.yaml** — registers `raw-meshrush-cairnpath-walk` + `derived-meshrush-slot-fill` (closed_beta; raw walk → derived slot-fill on the maturity ladder).
- **examples/meshrush-*.event.json** — conformant fixtures.
- **tools/validate_meshrush_events.py** — dependency-light stdlib validator (matches the other GDI validators): enforces the event-envelope (required fields, `^[a-z0-9_]+$` type, additionalProperties:false), checks topic registration, and **recomputes slot-fill counts** so a mislabeled example can't pass. Wired into `make validate`.

## Automatic on build + rollout
`serve.py` runs `make validate` continuously, and every `build-image` run + `validate.yml` runs it — so the MeshRush event class is checked on every GDI build and rollout, not manually. `make validate` green locally incl. the new gate.

Do **not** auto-merge — front-door by @mdheller.