### PR TITLE
feat(mesh): GDI-2 — mesh consume→produce loop (telemetry → ops findings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 *.py[cod]
 .pytest_cache/
+
+# GDI-2 mesh consume/produce runtime mailboxes (not source)
+mesh/

--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -103,11 +103,13 @@ third_party/ibm-itops/IMPORT-MANIFEST.v2.json
 third_party/ibm-itops/LICENSE.Apache-2.0
 third_party/ibm-itops/UPSTREAM.md
 tools/generate_github_footprint_itops_projection.py
+tools/mesh_consume.py
 tools/tests/fixtures/client-runtime-dump-exposure/allowed-synthetic.txt
 tools/tests/fixtures/client-runtime-dump-exposure/forbidden-positives.txt
 tools/tests/test_client_runtime_dump_exposure.py
 tools/tests/test_github_footprint_itops.py
 tools/tests/test_manifest.py
+tools/tests/test_mesh_consume.py
 tools/tests/test_model_fabric_release_readiness.py
 tools/tests/test_operational_exhaust_fusion.py
 tools/tests/test_serve.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate
+.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate mesh-consume
 
 validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate
 	@echo "OK: validate"
@@ -33,6 +33,9 @@ resource-contract-telemetry-validate:
 meshrush-events-validate:
 	python3 tools/validate_meshrush_events.py
 
+
+mesh-consume:
+	python3 tools/mesh_consume.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/serve.py
+++ b/serve.py
@@ -13,7 +13,7 @@ of this same validation core — see MESH_* env — and is the next increment.
 
 Stdlib only (keeps requirements.txt to PyYAML+pytest).
 """
-import os, subprocess, sys, threading, time
+import os, re, subprocess, sys, threading, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
@@ -29,9 +29,36 @@ def _int_env(key: str, default: int) -> int:
 
 PORT = _int_env("PORT", 8840)
 INTERVAL_S = _int_env("GDI_VALIDATE_INTERVAL_S", 300)
+# Mesh consume->produce loop (GDI-2), OFF by default so deployment behaviour is
+# unchanged until an operator opts in with MESH_ENABLED=1 (+ MESH_INPUT_DIR/MESH_OUTPUT_DIR).
+MESH_ENABLED = os.environ.get("MESH_ENABLED", "0").strip().lower() not in ("", "0", "false", "no")
+MESH_INTERVAL_S = _int_env("MESH_INTERVAL_S", 60)
 
 _state = {"last_rc": None, "last_ts": 0, "runs": 0, "fails": 0}
+_mesh = {"runs": 0, "consumed": 0, "produced": 0, "rejected": 0, "last_ts": 0}
 _lock = threading.Lock()
+
+
+def _mesh_loop() -> None:
+    """Run the mesh consume->produce loop on an interval (opt-in via MESH_ENABLED)."""
+    pat = re.compile(r"consumed=(\d+) produced=(\d+) rejected=(\d+)")
+    while True:
+        try:
+            r = subprocess.run(["python3", "tools/mesh_consume.py"], cwd=os.path.dirname(__file__) or ".",
+                               capture_output=True, text=True, timeout=300)
+            m = pat.search(r.stdout or "")
+            with _lock:
+                _mesh["runs"] += 1
+                _mesh["last_ts"] = int(time.time())
+                if m:
+                    _mesh["consumed"] += int(m.group(1))
+                    _mesh["produced"] += int(m.group(2))
+                    _mesh["rejected"] += int(m.group(3))
+            if r.returncode != 0:
+                sys.stderr.write(f"[gdi] mesh_consume rc={r.returncode}\n{r.stderr[-2000:]}\n")
+        except Exception as e:
+            sys.stderr.write(f"[gdi] mesh_consume errored: {e}\n")
+        time.sleep(MESH_INTERVAL_S)
 
 
 def _run_validators() -> None:
@@ -72,6 +99,26 @@ def _metrics() -> str:
         "# HELP gdi_last_run_timestamp_seconds unix ts of the last validator run.\n"
         "# TYPE gdi_last_run_timestamp_seconds gauge\n"
         f"gdi_last_run_timestamp_seconds {s['last_ts']}\n"
+        + _mesh_metrics()
+    )
+
+
+def _mesh_metrics() -> str:
+    with _lock:
+        m = dict(_mesh)
+    return (
+        "# HELP gdi_mesh_enabled 1 if the mesh consume loop is enabled.\n"
+        "# TYPE gdi_mesh_enabled gauge\n"
+        f"gdi_mesh_enabled {1 if MESH_ENABLED else 0}\n"
+        "# HELP gdi_mesh_consumed_total telemetry events consumed.\n"
+        "# TYPE gdi_mesh_consumed_total counter\n"
+        f"gdi_mesh_consumed_total {m['consumed']}\n"
+        "# HELP gdi_mesh_produced_total ops findings produced.\n"
+        "# TYPE gdi_mesh_produced_total counter\n"
+        f"gdi_mesh_produced_total {m['produced']}\n"
+        "# HELP gdi_mesh_rejected_total telemetry events rejected (fail-closed).\n"
+        "# TYPE gdi_mesh_rejected_total counter\n"
+        f"gdi_mesh_rejected_total {m['rejected']}\n"
     )
 
 
@@ -97,6 +144,8 @@ class H(BaseHTTPRequestHandler):
 
 def main() -> None:
     threading.Thread(target=_run_validators, daemon=True).start()
+    if MESH_ENABLED:
+        threading.Thread(target=_mesh_loop, daemon=True).start()
     ThreadingHTTPServer(("0.0.0.0", PORT), H).serve_forever()
 
 

--- a/serve.py
+++ b/serve.py
@@ -13,7 +13,7 @@ of this same validation core — see MESH_* env — and is the next increment.
 
 Stdlib only (keeps requirements.txt to PyYAML+pytest).
 """
-import os, re, subprocess, sys, threading, time
+import json, os, subprocess, sys, threading, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
@@ -41,19 +41,25 @@ _lock = threading.Lock()
 
 def _mesh_loop() -> None:
     """Run the mesh consume->produce loop on an interval (opt-in via MESH_ENABLED)."""
-    pat = re.compile(r"consumed=(\d+) produced=(\d+) rejected=(\d+)")
     while True:
         try:
             r = subprocess.run(["python3", "tools/mesh_consume.py"], cwd=os.path.dirname(__file__) or ".",
                                capture_output=True, text=True, timeout=300)
-            m = pat.search(r.stdout or "")
+            stats = None
+            for line in (r.stdout or "").splitlines():
+                if line.startswith("STATS "):
+                    try:
+                        stats = json.loads(line[len("STATS "):])
+                    except json.JSONDecodeError:
+                        stats = None
             with _lock:
                 _mesh["runs"] += 1
                 _mesh["last_ts"] = int(time.time())
-                if m:
-                    _mesh["consumed"] += int(m.group(1))
-                    _mesh["produced"] += int(m.group(2))
-                    _mesh["rejected"] += int(m.group(3))
+                if isinstance(stats, dict):
+                    for k in ("consumed", "produced", "rejected"):
+                        _mesh[k] += int(stats.get(k, 0))
+                else:
+                    sys.stderr.write("[gdi] mesh_consume: no parseable STATS line\n")
             if r.returncode != 0:
                 sys.stderr.write(f"[gdi] mesh_consume rc={r.returncode}\n{r.stderr[-2000:]}\n")
         except Exception as e:

--- a/tools/mesh_consume.py
+++ b/tools/mesh_consume.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""GDI mesh consume->produce loop (GDI-2): the increment serve.py flagged as next.
+
+Consumes telemetry AI4IT ``EventEnvelope``s from an inbox, validates them
+fail-closed against the event-envelope contract, and produces ``/ops/findings``
+RCA-claim EventEnvelopes to an outbox. This is the consume side of the live feed:
+MeshRush (via agentplane's MeshRush adapter) emits ``meshrush_*`` events; GDI
+ingests them here, normalizes, and turns the governance signal (e.g. refused
+slots) into an ops finding.
+
+Transport is a filesystem mailbox (MESH_INPUT_DIR / MESH_OUTPUT_DIR) — a real,
+dependency-free minimal mesh; swap for a bus later without changing this contract.
+
+Fail-closed: an envelope that does not conform is rejected (recorded, no finding
+produced) — a malformed telemetry item can never silently become a finding.
+Idempotent: a finding's name is derived from the source event, so re-running the
+loop does not duplicate findings.
+
+Stdlib only (matches the repo's dependency-light validators).
+"""
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "open-ai4it-spec/contracts/schemas/event-envelope.schema.json"
+_TYPE_RE = re.compile(r"^[a-z0-9_]+$")
+
+# MeshRush event types whose governance signal we surface as findings.
+_REFUSAL_SOURCE = "meshrush_slot_fill"
+
+
+def _now_fields() -> "tuple[int, str]":
+    dt = datetime.datetime.now(datetime.timezone.utc)
+    return int(dt.timestamp() * 1000), dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+def envelope_errors(event: object, schema: dict) -> list[str]:
+    """Fail-closed structural validation against the event-envelope (stdlib)."""
+    errs: list[str] = []
+    if not isinstance(event, dict):
+        return ["event is not an object"]
+    props = schema.get("properties", {})
+    for key in schema.get("required", []):
+        if key not in event:
+            errs.append(f"missing required '{key}'")
+    if schema.get("additionalProperties") is False:
+        extra = sorted(set(event) - set(props))
+        if extra:
+            errs.append(f"unexpected fields {extra}")
+    if "timestamp" in event and (not isinstance(event["timestamp"], int) or isinstance(event["timestamp"], bool)):
+        errs.append("timestamp must be an integer")
+    if "type" in event and not (isinstance(event["type"], str) and _TYPE_RE.fullmatch(event["type"])):
+        errs.append("type must match ^[a-z0-9_]+$")
+    return errs
+
+
+def _finding_for(event: dict, ts_ms: int, utc: str) -> dict:
+    """Build an /ops/findings RCA-claim EventEnvelope from a consumed event."""
+    src_type = event["type"]
+    story = event.get("story_id")
+    data = event.get("data", {}) if isinstance(event.get("data"), dict) else {}
+    severity, summary = "info", f"observed {src_type}"
+    signal: dict = {"source_type": src_type}
+
+    if src_type == _REFUSAL_SOURCE:
+        n_refused = data.get("n_refused", 0)
+        signal["n_refused"] = n_refused
+        signal["n_filled"] = data.get("n_filled", 0)
+        if isinstance(n_refused, int) and n_refused > 0:
+            severity = "warn"
+            summary = f"{n_refused} slot(s) refused during retrieval (governed abstention)"
+            signal["refused"] = data.get("refused", [])
+
+    finding = {
+        "timestamp": ts_ms,
+        "utc_timestamp": utc,
+        "type": "ops_finding",
+        "data_name": "rca_claim",
+        "data": {"severity": severity, "summary": summary, "signal": signal, "source_event_type": src_type},
+    }
+    if story is not None:
+        finding["story_id"] = story
+    return finding
+
+
+def consume_once(input_dir: Path, output_dir: Path, schema: dict, *, clock=_now_fields) -> dict:
+    """Consume every *.json envelope in ``input_dir``; write findings to ``output_dir``.
+
+    Returns stats ``{consumed, produced, rejected}``. Rejected envelopes are recorded
+    in ``output_dir/_rejected.log`` with their errors; no finding is produced for them.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stats = {"consumed": 0, "produced": 0, "rejected": 0}
+    rejected_log: list[str] = []
+
+    for path in sorted(input_dir.glob("*.json")) if input_dir.exists() else []:
+        stats["consumed"] += 1
+        try:
+            event = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            stats["rejected"] += 1
+            rejected_log.append(f"{path.name}: unreadable/invalid JSON ({exc})")
+            continue
+        errs = envelope_errors(event, schema)
+        if errs:
+            stats["rejected"] += 1
+            rejected_log.append(f"{path.name}: {'; '.join(errs)}")
+            continue
+        ts_ms, utc = clock()
+        finding = _finding_for(event, ts_ms, utc)
+        # Idempotent: derive the finding filename from the source event content.
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+        out = output_dir / f"finding-{digest}.json"
+        if not out.exists():
+            out.write_text(json.dumps(finding, indent=2) + "\n", encoding="utf-8")
+            stats["produced"] += 1
+
+    if rejected_log:
+        (output_dir / "_rejected.log").write_text("\n".join(rejected_log) + "\n", encoding="utf-8")
+    return stats
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    inbox = Path(os.environ.get("MESH_INPUT_DIR", str(ROOT / "mesh" / "telemetry")))
+    outbox = Path(os.environ.get("MESH_OUTPUT_DIR", str(ROOT / "mesh" / "ops-findings")))
+    stats = consume_once(inbox, outbox, schema)
+    print(f"OK: mesh consume — consumed={stats['consumed']} produced={stats['produced']} rejected={stats['rejected']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mesh_consume.py
+++ b/tools/mesh_consume.py
@@ -54,10 +54,24 @@ def envelope_errors(event: object, schema: dict) -> list[str]:
         extra = sorted(set(event) - set(props))
         if extra:
             errs.append(f"unexpected fields {extra}")
-    if "timestamp" in event and (not isinstance(event["timestamp"], int) or isinstance(event["timestamp"], bool)):
+    ts_ok = "timestamp" in event and isinstance(event["timestamp"], int) and not isinstance(event["timestamp"], bool)
+    if "timestamp" in event and not ts_ok:
         errs.append("timestamp must be an integer")
     if "type" in event and not (isinstance(event["type"], str) and _TYPE_RE.fullmatch(event["type"])):
         errs.append("type must match ^[a-z0-9_]+$")
+    utc = event.get("utc_timestamp")
+    utc_ok = isinstance(utc, str) and bool(utc)
+    if "utc_timestamp" in event and not utc_ok:
+        errs.append("utc_timestamp must be a non-empty string")
+    # Cross-check the two time fields agree (internally consistent event time),
+    # matching the stricter validation in tools/validate_meshrush_events.py.
+    if ts_ok and utc_ok:
+        try:
+            dt = datetime.datetime.fromisoformat(utc.replace("Z", "+00:00"))
+            if abs(int(dt.timestamp() * 1000) - event["timestamp"]) > 1000:
+                errs.append("timestamp disagrees with utc_timestamp")
+        except ValueError:
+            errs.append("utc_timestamp is not an RFC3339/ISO-8601 date-time")
     return errs
 
 
@@ -97,33 +111,47 @@ def consume_once(input_dir: Path, output_dir: Path, schema: dict, *, clock=_now_
     in ``output_dir/_rejected.log`` with their errors; no finding is produced for them.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
+    processed_dir = output_dir / "_processed"
+    rejected_dir = output_dir / "_rejected"
     stats = {"consumed": 0, "produced": 0, "rejected": 0}
     rejected_log: list[str] = []
 
+    def _drain(path: Path, dest_dir: Path) -> None:
+        # Move the source out of the inbox so a long-running loop consumes it once.
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / path.name
+        if dest.exists():  # avoid clobbering on name reuse
+            dest = dest_dir / f"{path.stem}.{hashlib.sha256(path.name.encode()).hexdigest()[:8]}{path.suffix}"
+        os.replace(path, dest)
+
     for path in sorted(input_dir.glob("*.json")) if input_dir.exists() else []:
         stats["consumed"] += 1
+        raw = path.read_bytes()
         try:
-            event = json.loads(path.read_text(encoding="utf-8"))
+            event = json.loads(raw)
         except (json.JSONDecodeError, OSError) as exc:
             stats["rejected"] += 1
             rejected_log.append(f"{path.name}: unreadable/invalid JSON ({exc})")
+            _drain(path, rejected_dir)
             continue
         errs = envelope_errors(event, schema)
         if errs:
             stats["rejected"] += 1
             rejected_log.append(f"{path.name}: {'; '.join(errs)}")
+            _drain(path, rejected_dir)
             continue
         ts_ms, utc = clock()
         finding = _finding_for(event, ts_ms, utc)
         # Idempotent: derive the finding filename from the source event content.
-        digest = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
-        out = output_dir / f"finding-{digest}.json"
+        out = output_dir / f"finding-{hashlib.sha256(raw).hexdigest()[:16]}.json"
         if not out.exists():
             out.write_text(json.dumps(finding, indent=2) + "\n", encoding="utf-8")
             stats["produced"] += 1
+        _drain(path, processed_dir)
 
     if rejected_log:
-        (output_dir / "_rejected.log").write_text("\n".join(rejected_log) + "\n", encoding="utf-8")
+        with (output_dir / "_rejected.log").open("a", encoding="utf-8") as fh:
+            fh.write("\n".join(rejected_log) + "\n")
     return stats
 
 
@@ -132,6 +160,8 @@ def main() -> int:
     inbox = Path(os.environ.get("MESH_INPUT_DIR", str(ROOT / "mesh" / "telemetry")))
     outbox = Path(os.environ.get("MESH_OUTPUT_DIR", str(ROOT / "mesh" / "ops-findings")))
     stats = consume_once(inbox, outbox, schema)
+    # Machine-readable stats line for serve.py (robust; not regex-parsed prose).
+    print("STATS " + json.dumps(stats, sort_keys=True))
     print(f"OK: mesh consume — consumed={stats['consumed']} produced={stats['produced']} rejected={stats['rejected']}")
     return 0
 

--- a/tools/tests/test_mesh_consume.py
+++ b/tools/tests/test_mesh_consume.py
@@ -49,19 +49,30 @@ def test_no_refusals_is_info_severity(tmp_path):
     assert finding["data"]["severity"] == "info"
 
 
-def test_malformed_envelope_is_rejected_not_findinged(tmp_path):
+def test_malformed_envelope_is_rejected_not_turned_into_finding(tmp_path):
     inbox, outbox = tmp_path / "in", tmp_path / "out"
     _write(inbox, "bad.json", {"type": "MeshRush", "data": {}})  # missing timestamp/utc; bad type
     stats = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
     assert stats["rejected"] == 1 and stats["produced"] == 0
     assert list(outbox.glob("finding-*.json")) == []
     assert (outbox / "_rejected.log").exists()
+    assert (outbox / "_rejected" / "bad.json").exists()  # drained out of the inbox
 
 
-def test_idempotent_no_duplicate_findings(tmp_path):
+def test_timestamp_utc_mismatch_is_rejected(tmp_path):
+    inbox, outbox = tmp_path / "in", tmp_path / "out"
+    ev = _valid_slot_fill()
+    ev["utc_timestamp"] = "2099-01-01T00:00:00.000Z"  # disagrees with timestamp
+    _write(inbox, "skew.json", ev)
+    stats = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
+    assert stats["rejected"] == 1 and stats["produced"] == 0
+
+
+def test_inbox_is_drained_so_reruns_do_not_reconsume(tmp_path):
     inbox, outbox = tmp_path / "in", tmp_path / "out"
     _write(inbox, "e1.json", _valid_slot_fill())
     consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
-    stats2 = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)  # re-run
-    assert stats2["produced"] == 0  # already produced
+    stats2 = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)  # re-run: inbox drained
+    assert stats2 == {"consumed": 0, "produced": 0, "rejected": 0}
     assert len(list(outbox.glob("finding-*.json"))) == 1
+    assert (outbox / "_processed" / "e1.json").exists()

--- a/tools/tests/test_mesh_consume.py
+++ b/tools/tests/test_mesh_consume.py
@@ -1,0 +1,67 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mesh_consume import consume_once, envelope_errors  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = json.loads((ROOT / "open-ai4it-spec/contracts/schemas/event-envelope.schema.json").read_text())
+CLOCK = lambda: (1785628800000, "2026-08-02T00:00:00.000Z")
+
+
+def _write(d: Path, name: str, obj: dict) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _valid_slot_fill(n_refused=1):
+    return {
+        "timestamp": 1785628800000, "utc_timestamp": "2026-08-02T00:00:00.000Z",
+        "type": "meshrush_slot_fill", "story_id": "s1",
+        "data": {"n_filled": 1, "n_refused": n_refused, "fills": [], "refused": [{"slot": "pricing", "reason": "floor"}]},
+    }
+
+
+def test_consumes_valid_event_and_produces_finding(tmp_path):
+    inbox, outbox = tmp_path / "in", tmp_path / "out"
+    _write(inbox, "e1.json", _valid_slot_fill())
+    stats = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
+    assert stats == {"consumed": 1, "produced": 1, "rejected": 0}
+    findings = list(outbox.glob("finding-*.json"))
+    assert len(findings) == 1
+    finding = json.loads(findings[0].read_text())
+    # The produced finding is itself a valid EventEnvelope.
+    assert envelope_errors(finding, SCHEMA) == []
+    # Refusals are surfaced as a warn-severity governance signal.
+    assert finding["type"] == "ops_finding"
+    assert finding["data"]["severity"] == "warn"
+    assert "refused" in finding["data"]["summary"]
+    assert finding["data"]["signal"]["n_refused"] == 1
+
+
+def test_no_refusals_is_info_severity(tmp_path):
+    inbox, outbox = tmp_path / "in", tmp_path / "out"
+    _write(inbox, "e1.json", _valid_slot_fill(n_refused=0))
+    consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
+    finding = json.loads(next(outbox.glob("finding-*.json")).read_text())
+    assert finding["data"]["severity"] == "info"
+
+
+def test_malformed_envelope_is_rejected_not_findinged(tmp_path):
+    inbox, outbox = tmp_path / "in", tmp_path / "out"
+    _write(inbox, "bad.json", {"type": "MeshRush", "data": {}})  # missing timestamp/utc; bad type
+    stats = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
+    assert stats["rejected"] == 1 and stats["produced"] == 0
+    assert list(outbox.glob("finding-*.json")) == []
+    assert (outbox / "_rejected.log").exists()
+
+
+def test_idempotent_no_duplicate_findings(tmp_path):
+    inbox, outbox = tmp_path / "in", tmp_path / "out"
+    _write(inbox, "e1.json", _valid_slot_fill())
+    consume_once(inbox, outbox, SCHEMA, clock=CLOCK)
+    stats2 = consume_once(inbox, outbox, SCHEMA, clock=CLOCK)  # re-run
+    assert stats2["produced"] == 0  # already produced
+    assert len(list(outbox.glob("finding-*.json"))) == 1


### PR DESCRIPTION
## What
Builds the increment `serve.py` flagged as next: **consume telemetry EventEnvelopes → produce `/ops/findings` RCA-claim EventEnvelopes**. This is the **consume side of the MeshRush→GDI live feed** (agentplane already owns emission via its MeshRush adapter contract, so this was the real bottleneck).

## How
- `tools/mesh_consume.py` — filesystem-mailbox transport (`MESH_INPUT_DIR`/`MESH_OUTPUT_DIR`), a real dependency-free minimal mesh (swap for a bus later, same contract).
  - **Fail-closed:** a malformed telemetry envelope is rejected + logged to `_rejected.log`, never becomes a finding.
  - **Governance signal surfaced:** a `meshrush_slot_fill` with refusals becomes a **warn**-severity ops finding naming the refused slots (retrieval abstention is an ops-intel signal). Produced findings are themselves valid EventEnvelopes.
  - **Idempotent:** finding filename derived from the source event → re-running doesn't duplicate.
- `serve.py` — optional mesh loop thread behind **`MESH_ENABLED` (OFF by default → deployment behaviour unchanged)** + `gdi_mesh_{consumed,produced,rejected}_total` Prometheus metrics.
- `Makefile` `mesh-consume` one-shot; `mesh/` runtime dirs gitignored; MANIFEST regenerated.

## Tests (4; make validate + make test green, 44)
consume valid → produce finding (valid envelope) · refusals → warn severity + named slots · no refusals → info · malformed → rejected, no finding · idempotent re-run.

## Sequence
GDI-2 (consume side). Follow-up GDI-2b: swap file-mailbox for the chosen bus + agentplane live wire.

Do **not** auto-merge — front-door by @mdheller.