### PR TITLE
GDI-2c — HTTP telemetry ingest over the in-process bus (agentplane live wire)

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -16,6 +16,11 @@ Stdlib only (keeps requirements.txt to PyYAML+pytest).
 import json, os, subprocess, sys, threading, time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# GDI-2c: reuse the mesh transport/consume core for the in-process bus + HTTP ingest.
+sys.path.insert(0, os.path.join(_HERE, "tools"))
+from mesh_consume import InMemoryBus, consume  # noqa: E402
+
 
 def _int_env(key: str, default: int) -> int:
     """Parse an int env var, falling back to default on a malformed value so a
@@ -33,10 +38,28 @@ INTERVAL_S = _int_env("GDI_VALIDATE_INTERVAL_S", 300)
 # unchanged until an operator opts in with MESH_ENABLED=1 (+ MESH_INPUT_DIR/MESH_OUTPUT_DIR).
 MESH_ENABLED = os.environ.get("MESH_ENABLED", "0").strip().lower() not in ("", "0", "false", "no")
 MESH_INTERVAL_S = _int_env("MESH_INTERVAL_S", 60)
+# GDI-2c: cap the HTTP telemetry body (fail-closed against oversized posts).
+MESH_MAX_BODY = _int_env("MESH_MAX_BODY", 1 << 20)
 
 _state = {"last_rc": None, "last_ts": 0, "runs": 0, "fails": 0}
 _mesh = {"runs": 0, "consumed": 0, "produced": 0, "rejected": 0, "last_ts": 0}
 _lock = threading.Lock()
+
+# GDI-2c: the in-process bus behind POST /mesh/telemetry (the agentplane live wire).
+# agentplane POSTs telemetry -> published here -> drained by the mesh loop with the
+# same consume() contract. No networked broker is pinned (sovereign).
+_BUS = InMemoryBus()
+_mesh_schema_cache = None
+
+
+def _mesh_schema() -> dict:
+    """Load (and cache) the event-envelope schema; path-anchored, cwd-independent."""
+    global _mesh_schema_cache
+    if _mesh_schema_cache is None:
+        path = os.path.join(_HERE, "open-ai4it-spec/contracts/schemas/event-envelope.schema.json")
+        with open(path, encoding="utf-8") as fh:
+            _mesh_schema_cache = json.load(fh)
+    return _mesh_schema_cache
 
 
 def _mesh_loop() -> None:
@@ -64,6 +87,14 @@ def _mesh_loop() -> None:
                 sys.stderr.write(f"[gdi] mesh_consume rc={r.returncode}\n{r.stderr[-2000:]}\n")
         except Exception as e:
             sys.stderr.write(f"[gdi] mesh_consume errored: {e}\n")
+        # GDI-2c: also drain the in-process bus (HTTP-ingested telemetry), same contract.
+        try:
+            bstats = consume(_BUS, _mesh_schema())
+            with _lock:
+                for k in ("consumed", "produced", "rejected"):
+                    _mesh[k] += int(bstats.get(k, 0))
+        except Exception as e:
+            sys.stderr.write(f"[gdi] mesh bus drain errored: {e}\n")
         time.sleep(MESH_INTERVAL_S)
 
 
@@ -125,6 +156,9 @@ def _mesh_metrics() -> str:
         "# HELP gdi_mesh_rejected_total telemetry events rejected (fail-closed).\n"
         "# TYPE gdi_mesh_rejected_total counter\n"
         f"gdi_mesh_rejected_total {m['rejected']}\n"
+        "# HELP gdi_mesh_bus_pending telemetry envelopes on the in-process bus awaiting drain.\n"
+        "# TYPE gdi_mesh_bus_pending gauge\n"
+        f"gdi_mesh_bus_pending {len(_BUS.poll())}\n"
     )
 
 
@@ -146,6 +180,37 @@ class H(BaseHTTPRequestHandler):
             self.end_headers(); self.wfile.write(body)
         else:
             self.send_response(404); self.end_headers()
+
+    def _reply(self, code: int, obj: dict) -> None:
+        body = (json.dumps(obj) + "\n").encode()
+        self.send_response(code); self.send_header("Content-Type", "application/json")
+        self.end_headers(); self.wfile.write(body)
+
+    def do_POST(self):
+        # GDI-2c: agentplane (or any producer) posts a telemetry EventEnvelope here;
+        # it is published onto the in-process bus and drained by the mesh loop under
+        # the same fail-closed consume() contract. Off unless MESH_ENABLED.
+        if self.path != "/mesh/telemetry":
+            self.send_response(404); self.end_headers(); return
+        if not MESH_ENABLED:
+            self._reply(503, {"error": "mesh disabled"}); return
+        try:
+            length = int(self.headers.get("Content-Length", 0) or 0)
+        except (ValueError, TypeError):
+            length = -1
+        if length <= 0:
+            self._reply(400, {"error": "missing/invalid Content-Length"}); return
+        if length > MESH_MAX_BODY:
+            self._reply(413, {"error": f"body exceeds {MESH_MAX_BODY} bytes"}); return
+        body = self.rfile.read(length)
+        # Edge guard: reject blatantly non-JSON at ingest (envelope validation still
+        # happens fail-closed at consume time); don't let junk fill the bus.
+        try:
+            json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            self._reply(400, {"error": "body is not valid JSON"}); return
+        msg_id = _BUS.publish_telemetry(body)
+        self._reply(202, {"accepted": msg_id})
 
 
 def main() -> None:

--- a/tools/tests/test_serve.py
+++ b/tools/tests/test_serve.py
@@ -1,12 +1,35 @@
 """Tests for the serve.py runtime: crash-safe env parsing + Prometheus
-exposition format + readiness logic. Loads serve.py by path (repo root)."""
+exposition format + readiness logic + the GDI-2c mesh HTTP ingest. Loads serve.py
+by path (repo root)."""
+import http.client
 import importlib.util
+import json
 import os
+import threading
+from http.server import ThreadingHTTPServer
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 _spec = importlib.util.spec_from_file_location("gdi_serve", os.path.join(ROOT, "serve.py"))
 serve = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(serve)
+
+
+def _serve_and_post(path, body, *, mesh_enabled, headers=None):
+    """Start serve.H on an ephemeral port, POST once, return (status, body)."""
+    serve.MESH_ENABLED = mesh_enabled
+    serve._BUS = serve.InMemoryBus()  # fresh bus per call
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), serve.H)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        payload = body if isinstance(body, (bytes, str)) else json.dumps(body)
+        conn.request("POST", path, body=payload, headers=headers or {})
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        srv.shutdown()
 
 
 def test_int_env_falls_back_on_malformed():
@@ -38,3 +61,56 @@ def test_gdi_up_reflects_last_rc():
     with serve._lock:
         serve._state.update(last_rc=0)
     assert "gdi_up 1" in serve._metrics()
+
+
+# --- GDI-2c: mesh HTTP ingest --------------------------------------------------
+
+_EVENT = {
+    "timestamp": 1785628800000, "utc_timestamp": "2026-08-02T00:00:00.000Z",
+    "type": "meshrush_slot_fill", "data": {"n_filled": 1, "n_refused": 0, "fills": [], "refused": []},
+}
+
+
+def test_ingest_publishes_to_bus_when_enabled():
+    status, body = _serve_and_post(
+        "/mesh/telemetry", _EVENT, mesh_enabled=True,
+        headers={"Content-Length": str(len(json.dumps(_EVENT)))},
+    )
+    assert status == 202
+    assert "accepted" in json.loads(body)
+    assert len(serve._BUS.poll()) == 1  # the event is on the bus
+
+
+def test_ingest_is_disabled_by_default():
+    status, _ = _serve_and_post(
+        "/mesh/telemetry", _EVENT, mesh_enabled=False,
+        headers={"Content-Length": str(len(json.dumps(_EVENT)))},
+    )
+    assert status == 503
+
+
+def test_ingest_rejects_non_json():
+    status, _ = _serve_and_post(
+        "/mesh/telemetry", "{not json", mesh_enabled=True,
+        headers={"Content-Length": str(len("{not json"))},
+    )
+    assert status == 400
+    assert len(serve._BUS.poll()) == 0  # junk never reached the bus
+
+
+def test_ingest_rejects_oversized_body():
+    serve.MESH_MAX_BODY = 10  # tiny cap for the test
+    try:
+        status, _ = _serve_and_post(
+            "/mesh/telemetry", _EVENT, mesh_enabled=True,
+            headers={"Content-Length": str(len(json.dumps(_EVENT)))},
+        )
+        assert status == 413
+    finally:
+        serve.MESH_MAX_BODY = 1 << 20
+
+
+def test_mesh_bus_pending_metric_present():
+    serve._BUS = serve.InMemoryBus()
+    serve._BUS.publish_telemetry(json.dumps(_EVENT))
+    assert "gdi_mesh_bus_pending 1" in serve._metrics()


### PR DESCRIPTION
## GDI-2c — the networked wire, sovereign (no broker dependency)

GDI-2b added the `InMemoryBus`. This makes it **network-reachable** so agentplane can push telemetry live — using only stdlib `http.server`, no NATS/Redis/Kafka client pinned.

- **`POST /mesh/telemetry`** publishes the posted EventEnvelope onto the shared `InMemoryBus`; the mesh loop drains it each interval via the *same* fail-closed `consume()` contract. Findings fold into the existing `gdi_mesh_*` counters, plus a new `gdi_mesh_bus_pending` gauge.
- **Opt-in**: `503` unless `MESH_ENABLED` — default deployment behaviour is unchanged.
- **Fail-closed edge**: missing/invalid `Content-Length` → `400`; body > `MESH_MAX_BODY` (1 MB) → `413`; non-JSON body → `400` (never reaches the bus). Full envelope conformance is still enforced fail-closed at consume time.
- Reuses `tools/mesh_consume` (`InMemoryBus`, `consume`); stdlib only.

### Verification
- +5 serve tests over a live ephemeral server: ingest publishes when enabled; disabled → 503; non-JSON → 400 (bus stays empty); oversized → 413; `gdi_mesh_bus_pending` metric present.
- `make test` **54 green**; `make validate` green.

This closes the MeshRush→GDI live feed: **agentplane POSTs → bus → consume → ops findings**, end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)