### PR TITLE
feat(story_services): incident-similarity contract + deterministic scorer (AI4IT Pipeline 3)

### DIFF
--- a/MANIFEST.txt
+++ b/MANIFEST.txt
@@ -48,6 +48,7 @@ docs/architecture/api-interactions-decision.md
 docs/architecture/broker-operational-intelligence-binding.md
 docs/architecture/browser-telemetry-finding-model.md
 docs/architecture/github-footprint-itops-alignment.md
+docs/architecture/incident-similarity-service.md
 docs/architecture/institutional-account-hierarchy-itops.md
 docs/architecture/ops-ingestion-and-measurement-plane.md
 docs/architecture/runtime-control-plane-telemetry-alignment.md
@@ -67,6 +68,12 @@ examples/browser-telemetry-findings/chatgpt-console-trace-classification.example
 examples/client-runtime-dump-exposure-sample.yaml
 examples/github-footprint-itops-generated.yaml
 examples/github-footprint-itops-sample.yaml
+examples/incident-similarity/corpus.example.json
+examples/incident-similarity/invalid/corpus-missing-id.json
+examples/incident-similarity/invalid/query-empty-terms.json
+examples/incident-similarity/invalid/result-tampered-score.json
+examples/incident-similarity/query.example.json
+examples/incident-similarity/result.expected.json
 examples/meshrush-cairnpath-walk.event.json
 examples/meshrush-slot-fill.event.json
 examples/model-fabric-release-readiness.example.json
@@ -81,9 +88,13 @@ mappings/runtime-control-plane-telemetry-v2.yaml
 open-ai4it-spec/README.md
 open-ai4it-spec/contracts/schemas/entity-output.schema.json
 open-ai4it-spec/contracts/schemas/event-envelope.schema.json
+open-ai4it-spec/contracts/schemas/incident-similarity-query.schema.json
+open-ai4it-spec/contracts/schemas/incident-similarity-result.schema.json
 open-ai4it-spec/contracts/topics/topics.yaml
 open-ai4it-spec/docs/glossary/TERMS.md
 open-ai4it-spec/modules/openentitymap/mapping.schema.json
+open-ai4it-spec/modules/story_services/README.md
+open-ai4it-spec/modules/story_services/incident_similarity/scorer.py
 profiles/browser-telemetry-risk-profile.v0.yaml
 profiles/client-runtime-dump-exposure-profile.v0.yaml
 profiles/github-footprint-itops-expansion.yaml
@@ -108,6 +119,7 @@ tools/tests/fixtures/client-runtime-dump-exposure/allowed-synthetic.txt
 tools/tests/fixtures/client-runtime-dump-exposure/forbidden-positives.txt
 tools/tests/test_client_runtime_dump_exposure.py
 tools/tests/test_github_footprint_itops.py
+tools/tests/test_incident_similarity.py
 tools/tests/test_manifest.py
 tools/tests/test_mesh_consume.py
 tools/tests/test_model_fabric_release_readiness.py
@@ -116,6 +128,7 @@ tools/tests/test_serve.py
 tools/tests/test_service_desk_metrics.py
 tools/validate_client_runtime_dump_exposure.py
 tools/validate_github_footprint_itops.py
+tools/validate_incident_similarity.py
 tools/validate_manifest.py
 tools/validate_meshrush_events.py
 tools/validate_model_fabric_release_readiness.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate mesh-consume
+.PHONY: validate test manifest-validate manifest-write service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate github-footprint-itops-generated-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate mesh-consume incident-similarity-validate
 
-validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate
+validate: manifest-validate service-desk-metrics-validate model-fabric-release-readiness-validate github-footprint-itops-validate client-runtime-dump-exposure-validate operational-exhaust-fusion-validate resource-contract-telemetry-validate meshrush-events-validate incident-similarity-validate
 	@echo "OK: validate"
 
 manifest-validate:
@@ -32,6 +32,9 @@ resource-contract-telemetry-validate:
 
 meshrush-events-validate:
 	python3 tools/validate_meshrush_events.py
+
+incident-similarity-validate:
+	python3 tools/validate_incident_similarity.py
 
 
 mesh-consume:

--- a/docs/architecture/incident-similarity-service.md
+++ b/docs/architecture/incident-similarity-service.md
@@ -1,0 +1,90 @@
+# Incident Similarity Service (AI4IT Pipeline 3)
+
+## Where this sits
+
+The AI4IT reference architecture (an IBM Watson-AIOps-style design) has three
+pipelines:
+
+1. **Log Anomaly** — ingest large log volumes, detect anomalies per log.
+2. **Event Grouping** — group events/alerts + log anomalies into incident
+   "stories".
+3. **Incident Similarity** — match incidents to the search terms an SRE
+   provides.
+
+This document specifies the first buildable slice of **Pipeline 3**, the
+*Similar Incidents Service*, delivered as a sovereign contract + deterministic
+scorer under `open-ai4it-spec/modules/story_services/incident_similarity/`.
+
+We build our own equivalent (MIT / standard-library Python); we do not vendor or
+fork any IBM/Watson proprietary component. The IBM ITOPS seed under
+`third_party/ibm-itops/` remains an ontology seed only (see ADR 0001), not code.
+
+## Contract
+
+- **Query** (`incident-similarity-query.schema.json`): the SRE's free-text
+  `terms`, a `query_id`, an optional `as_of_utc` (so the recency signal is
+  time-independent and reproducible), optional `top_k`, and optional `weights` /
+  `thresholds` overrides.
+- **Result** (`incident-similarity-result.schema.json`): ranked `matches`, each
+  with the raw per-signal `signals`, an `explainability` breakdown
+  (`matched_terms` + `weighted_contributions`), an Assay `verdict`, plus a
+  `receipt` sealing the whole computation under a SHA-256 trace hash.
+
+These align with the AI4IT event envelope (`contracts/schemas/event-envelope.schema.json`):
+a result maps onto an `insight` message whose `explainability` is the per-match
+breakdown, whose `story_id` is the query id, and whose `feedback` slot is where
+SRE thumbs-up/down would later close the loop.
+
+## Scoring model (deterministic)
+
+Final score is a weighted, normalized sum of four signals in `[0, 1]`:
+
+| Signal | Definition | Default weight |
+|---|---|---|
+| `lexical` | Jaccard of query tokens vs incident title+summary+tags+entities | 0.5 |
+| `entity_overlap` | Jaccard of query tokens vs incident entity tokens | 0.2 |
+| `topology` | `1 / (1 + topology_distance)` (hops in the service graph) | 0.2 |
+| `recency` | `1 / (1 + age_days)` measured against `as_of_utc` | 0.1 |
+
+Weights are renormalized to sum 1. Ranking is score-descending with a stable
+`incident_id` tie-break. Every emitted float is rounded to 6 decimals so output
+is byte-reproducible across platforms — the precondition for the golden-file
+teeth.
+
+## Reused estate primitives
+
+- **Receipt spine (provenance).** `build_receipt` seals the normalized query
+  terms, sorted corpus ids, weights, thresholds, and the ranked `(id, score)`
+  list under `sha256(...)` and emits `trace_hash: "sha256:<64 hex>"`. This is the
+  same provenance discipline as sourceos-spec `ReasoningReceipt` and the
+  platform `EvidenceReceipt`, kept offline and self-verifying. SHA-256 is the
+  **FIPS-180-4 algorithm** — this is not a FIPS-140 cryptographic-module claim.
+- **The Assay (ok/sad/bad).** `project_verdict` renders `(method, score)` to a
+  verdict at read time: `ok` above the `ok` threshold, `sad` (real but
+  low-confidence / unassayed) between `sad` and `ok`, `bad` below. `method` is
+  always `computed` because the score is deterministic arithmetic, never
+  generative. Because the verdict is a projection, history is re-judgeable if
+  thresholds are recalibrated — the validator recomputes it and fails on drift.
+- **HellGraph topology.** `topology_distance` is the hop count from the query's
+  focus service to a candidate in the service topology graph. Modeling it as an
+  input field keeps the scorer deterministic and unit-testable offline while, in
+  production, the field is populated from the live HellGraph service graph.
+
+## Teeth
+
+`tools/validate_incident_similarity.py` (in `make validate`, run in CI) asserts:
+golden reproducibility, determinism, receipt integrity, Assay projection
+soundness, JSON-Schema conformance, and — both ways — that malformed inputs are
+refused and a tampered result is detected as drift. `tools/tests/test_incident_similarity.py`
+pins the same properties under pytest.
+
+## What this deliberately is not (roadmap)
+
+- No dense/embedding leg. Estate has `hellgraph/ts/src/bm25.ts`,
+  `retrieval.ts` (RRF/MMR), and `sherlock-engine` (BM25⊕dense via RRF over
+  Qdrant) — a hybrid upgrade path exists but is out of scope for this
+  deterministic, dependency-free first slice.
+- No event grouping / log-anomaly detection — those are Pipelines 2 and 1 and
+  remain GAPs (tracked in the AIOps program issue).
+- No live ASM ingestion — the topology signal consumes a distance field rather
+  than discovering topology itself.

--- a/examples/incident-similarity/corpus.example.json
+++ b/examples/incident-similarity/corpus.example.json
@@ -1,0 +1,41 @@
+[
+  {
+    "incident_id": "inc-1042",
+    "title": "Checkout payment gateway returning 502",
+    "summary": "Payment gateway timeout caused checkout 502 errors during peak traffic.",
+    "tags": ["checkout", "payment", "gateway", "5xx"],
+    "entities": ["payment-gateway", "checkout-service"],
+    "service_ref": "checkout-service",
+    "topology_distance": 0,
+    "opened_utc": "2026-08-01T12:00:00Z"
+  },
+  {
+    "incident_id": "inc-0991",
+    "title": "Payment provider latency spike",
+    "summary": "Upstream payment provider added latency; some gateway timeouts observed.",
+    "tags": ["payment", "latency", "gateway"],
+    "entities": ["payment-gateway"],
+    "service_ref": "payment-gateway",
+    "topology_distance": 1,
+    "opened_utc": "2026-07-20T09:30:00Z"
+  },
+  {
+    "incident_id": "inc-0777",
+    "title": "Checkout cart persistence failure",
+    "summary": "Cart items not persisting; unrelated to payment path.",
+    "tags": ["checkout", "cart", "database"],
+    "entities": ["cart-service"],
+    "service_ref": "cart-service",
+    "topology_distance": 3,
+    "opened_utc": "2026-06-15T18:00:00Z"
+  },
+  {
+    "incident_id": "inc-0500",
+    "title": "Marketing site CDN cache miss storm",
+    "summary": "CDN misconfiguration caused cache miss storm on the marketing site.",
+    "tags": ["cdn", "marketing", "cache"],
+    "entities": ["cdn-edge"],
+    "service_ref": "marketing-web",
+    "opened_utc": "2026-05-01T00:00:00Z"
+  }
+]

--- a/examples/incident-similarity/invalid/corpus-missing-id.json
+++ b/examples/incident-similarity/invalid/corpus-missing-id.json
@@ -1,0 +1,8 @@
+[
+  {
+    "title": "An incident with no incident_id",
+    "summary": "The scorer must refuse a corpus entry that cannot be identified.",
+    "tags": ["checkout"],
+    "entities": ["checkout-service"]
+  }
+]

--- a/examples/incident-similarity/invalid/query-empty-terms.json
+++ b/examples/incident-similarity/invalid/query-empty-terms.json
@@ -1,0 +1,4 @@
+{
+  "query_id": "isq-invalid-empty-terms",
+  "terms": []
+}

--- a/examples/incident-similarity/invalid/result-tampered-score.json
+++ b/examples/incident-similarity/invalid/result-tampered-score.json
@@ -1,0 +1,134 @@
+{
+  "as_of_utc": "2026-08-03T00:00:00Z",
+  "matches": [
+    {
+      "explainability": {
+        "matched_terms": [
+          "502",
+          "checkout",
+          "gateway",
+          "payment",
+          "timeout"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.1,
+          "lexical": 0.192308,
+          "recency": 0.04,
+          "topology": 0.2
+        }
+      },
+      "incident_id": "inc-1042",
+      "rank": 0,
+      "score": 0.532308,
+      "signals": {
+        "entity_overlap": 0.5,
+        "lexical": 0.384615,
+        "recency": 0.4,
+        "topology": 1.0
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "ok"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [
+          "gateway",
+          "payment"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.08,
+          "lexical": 0.076923,
+          "recency": 0.006847,
+          "topology": 0.1
+        }
+      },
+      "incident_id": "inc-0991",
+      "rank": 1,
+      "score": 0.26377,
+      "signals": {
+        "entity_overlap": 0.4,
+        "lexical": 0.153846,
+        "recency": 0.068474,
+        "topology": 0.5
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "sad"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [
+          "checkout",
+          "payment"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.0,
+          "lexical": 0.0625,
+          "recency": 0.00203,
+          "topology": 0.05
+        }
+      },
+      "incident_id": "inc-0777",
+      "rank": 2,
+      "score": 0.11453,
+      "signals": {
+        "entity_overlap": 0.0,
+        "lexical": 0.125,
+        "recency": 0.020305,
+        "topology": 0.25
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "bad"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [],
+        "weighted_contributions": {
+          "entity_overlap": 0.0,
+          "lexical": 0.0,
+          "recency": 0.001053,
+          "topology": 0.0
+        }
+      },
+      "incident_id": "inc-0500",
+      "rank": 3,
+      "score": 0.99,
+      "signals": {
+        "entity_overlap": 0.0,
+        "lexical": 0.0,
+        "recency": 0.010526,
+        "topology": 0.0
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "ok"
+      }
+    }
+  ],
+  "query_id": "isq-2026-08-03-checkout-5xx",
+  "receipt": {
+    "algorithm": "sha256",
+    "candidate_count": 4,
+    "match_count": 4,
+    "query_id": "isq-2026-08-03-checkout-5xx",
+    "receipt_version": "0.1.0",
+    "trace_hash": "sha256:febbf5782da5b5038d09dcd661105bf769684f47040791bfc815e3bdf352cf2d"
+  },
+  "schema_version": "0.1.0",
+  "thresholds": {
+    "min_score": 0.0,
+    "ok": 0.5,
+    "sad": 0.2
+  },
+  "weights": {
+    "entity_overlap": 0.2,
+    "lexical": 0.5,
+    "recency": 0.1,
+    "topology": 0.2
+  }
+}

--- a/examples/incident-similarity/query.example.json
+++ b/examples/incident-similarity/query.example.json
@@ -1,0 +1,12 @@
+{
+  "query_id": "isq-2026-08-03-checkout-5xx",
+  "terms": [
+    "checkout",
+    "payment",
+    "502",
+    "gateway",
+    "timeout"
+  ],
+  "as_of_utc": "2026-08-03T00:00:00Z",
+  "top_k": 4
+}

--- a/examples/incident-similarity/result.expected.json
+++ b/examples/incident-similarity/result.expected.json
@@ -1,0 +1,134 @@
+{
+  "as_of_utc": "2026-08-03T00:00:00Z",
+  "matches": [
+    {
+      "explainability": {
+        "matched_terms": [
+          "502",
+          "checkout",
+          "gateway",
+          "payment",
+          "timeout"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.1,
+          "lexical": 0.192308,
+          "recency": 0.04,
+          "topology": 0.2
+        }
+      },
+      "incident_id": "inc-1042",
+      "rank": 0,
+      "score": 0.532308,
+      "signals": {
+        "entity_overlap": 0.5,
+        "lexical": 0.384615,
+        "recency": 0.4,
+        "topology": 1.0
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "ok"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [
+          "gateway",
+          "payment"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.08,
+          "lexical": 0.076923,
+          "recency": 0.006847,
+          "topology": 0.1
+        }
+      },
+      "incident_id": "inc-0991",
+      "rank": 1,
+      "score": 0.26377,
+      "signals": {
+        "entity_overlap": 0.4,
+        "lexical": 0.153846,
+        "recency": 0.068474,
+        "topology": 0.5
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "sad"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [
+          "checkout",
+          "payment"
+        ],
+        "weighted_contributions": {
+          "entity_overlap": 0.0,
+          "lexical": 0.0625,
+          "recency": 0.00203,
+          "topology": 0.05
+        }
+      },
+      "incident_id": "inc-0777",
+      "rank": 2,
+      "score": 0.11453,
+      "signals": {
+        "entity_overlap": 0.0,
+        "lexical": 0.125,
+        "recency": 0.020305,
+        "topology": 0.25
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "bad"
+      }
+    },
+    {
+      "explainability": {
+        "matched_terms": [],
+        "weighted_contributions": {
+          "entity_overlap": 0.0,
+          "lexical": 0.0,
+          "recency": 0.001053,
+          "topology": 0.0
+        }
+      },
+      "incident_id": "inc-0500",
+      "rank": 3,
+      "score": 0.001053,
+      "signals": {
+        "entity_overlap": 0.0,
+        "lexical": 0.0,
+        "recency": 0.010526,
+        "topology": 0.0
+      },
+      "verdict": {
+        "method": "computed",
+        "state": "bad"
+      }
+    }
+  ],
+  "query_id": "isq-2026-08-03-checkout-5xx",
+  "receipt": {
+    "algorithm": "sha256",
+    "candidate_count": 4,
+    "match_count": 4,
+    "query_id": "isq-2026-08-03-checkout-5xx",
+    "receipt_version": "0.1.0",
+    "trace_hash": "sha256:febbf5782da5b5038d09dcd661105bf769684f47040791bfc815e3bdf352cf2d"
+  },
+  "schema_version": "0.1.0",
+  "thresholds": {
+    "min_score": 0.0,
+    "ok": 0.5,
+    "sad": 0.2
+  },
+  "weights": {
+    "entity_overlap": 0.2,
+    "lexical": 0.5,
+    "recency": 0.1,
+    "topology": 0.2
+  }
+}

--- a/open-ai4it-spec/contracts/schemas/incident-similarity-query.schema.json
+++ b/open-ai4it-spec/contracts/schemas/incident-similarity-query.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI4IT Incident Similarity Query",
+  "description": "Search terms an SRE provides to the Similar Incidents Service, plus optional scoring overrides. Pipeline 3 of the AI4IT reference architecture.",
+  "type": "object",
+  "required": [
+    "query_id",
+    "terms"
+  ],
+  "properties": {
+    "query_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for this query; echoed into the result and sealed into the receipt."
+    },
+    "terms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      },
+      "description": "Free-text search terms from the SRE. Tokenized lowercase on non-alphanumeric boundaries."
+    },
+    "as_of_utc": {
+      "type": "string",
+      "description": "RFC3339/ISO-8601 UTC instant the recency signal is measured against. Supplied explicitly so scoring is time-independent and reproducible; omit to disable the recency signal."
+    },
+    "top_k": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional cap on the number of ranked matches returned (after min_score filtering)."
+    },
+    "weights": {
+      "type": "object",
+      "description": "Optional overrides for the per-signal weights (normalized to sum 1 at scoring time).",
+      "properties": {
+        "lexical": { "type": "number", "minimum": 0 },
+        "entity_overlap": { "type": "number", "minimum": 0 },
+        "topology": { "type": "number", "minimum": 0 },
+        "recency": { "type": "number", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "thresholds": {
+      "type": "object",
+      "description": "Optional overrides for the Assay verdict bands and match floor.",
+      "properties": {
+        "ok": { "type": "number", "minimum": 0, "maximum": 1 },
+        "sad": { "type": "number", "minimum": 0, "maximum": 1 },
+        "min_score": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/open-ai4it-spec/contracts/schemas/incident-similarity-result.schema.json
+++ b/open-ai4it-spec/contracts/schemas/incident-similarity-result.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI4IT Incident Similarity Result",
+  "description": "Ranked similar-incident matches with per-signal explainability, an Assay verdict, and a SHA-256 provenance receipt. Output of the Similar Incidents Service (Pipeline 3).",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "query_id",
+    "weights",
+    "thresholds",
+    "matches",
+    "receipt"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "query_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "as_of_utc": {
+      "type": ["string", "null"],
+      "description": "Echo of the query as_of_utc used for the recency signal (null if none supplied)."
+    },
+    "weights": {
+      "type": "object",
+      "required": ["lexical", "entity_overlap", "topology", "recency"],
+      "properties": {
+        "lexical": { "type": "number" },
+        "entity_overlap": { "type": "number" },
+        "topology": { "type": "number" },
+        "recency": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "thresholds": {
+      "type": "object",
+      "required": ["ok", "sad", "min_score"],
+      "properties": {
+        "ok": { "type": "number" },
+        "sad": { "type": "number" },
+        "min_score": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "matches": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/match" }
+    },
+    "receipt": { "$ref": "#/$defs/receipt" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "match": {
+      "type": "object",
+      "required": [
+        "incident_id",
+        "rank",
+        "score",
+        "signals",
+        "explainability",
+        "verdict"
+      ],
+      "properties": {
+        "incident_id": { "type": "string", "minLength": 1 },
+        "rank": { "type": "integer", "minimum": 0 },
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "signals": {
+          "type": "object",
+          "required": ["lexical", "entity_overlap", "topology", "recency"],
+          "properties": {
+            "lexical": { "type": "number", "minimum": 0, "maximum": 1 },
+            "entity_overlap": { "type": "number", "minimum": 0, "maximum": 1 },
+            "topology": { "type": "number", "minimum": 0, "maximum": 1 },
+            "recency": { "type": "number", "minimum": 0, "maximum": 1 }
+          },
+          "additionalProperties": false
+        },
+        "explainability": {
+          "type": "object",
+          "required": ["matched_terms", "weighted_contributions"],
+          "properties": {
+            "matched_terms": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "weighted_contributions": {
+              "type": "object",
+              "required": ["lexical", "entity_overlap", "topology", "recency"],
+              "properties": {
+                "lexical": { "type": "number" },
+                "entity_overlap": { "type": "number" },
+                "topology": { "type": "number" },
+                "recency": { "type": "number" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "verdict": {
+          "type": "object",
+          "required": ["state", "method"],
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["ok", "sad", "bad"],
+              "description": "Assay projection over the final score. ok = confident match; sad = real but low-confidence (unassayed); bad = too weak to trust."
+            },
+            "method": {
+              "type": "string",
+              "const": "computed",
+              "description": "Always computed: the score is deterministic lexical/graph arithmetic, never generative."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "receipt": {
+      "type": "object",
+      "required": [
+        "receipt_version",
+        "algorithm",
+        "trace_hash",
+        "candidate_count",
+        "match_count"
+      ],
+      "properties": {
+        "receipt_version": { "type": "string", "const": "0.1.0" },
+        "algorithm": {
+          "type": "string",
+          "const": "sha256",
+          "description": "SHA-256 (FIPS-180-4 algorithm). Not a FIPS-140 module claim."
+        },
+        "trace_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Hash over normalized query terms, sorted corpus ids, weights, thresholds, and the ranked (id, score) result."
+        },
+        "query_id": { "type": ["string", "null"] },
+        "candidate_count": { "type": "integer", "minimum": 0 },
+        "match_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/open-ai4it-spec/modules/story_services/README.md
+++ b/open-ai4it-spec/modules/story_services/README.md
@@ -1,0 +1,51 @@
+# story_services
+
+The `story_services` module is the AI4IT reference architecture's third stage:
+turning grouped alerts/incidents into things an SRE can act on. It covers four
+independently-replaceable services:
+
+| Service | Reference role | Status in this repo |
+|---|---|---|
+| `incident_similarity/` | Similar Incidents Service — rank prior incidents against SRE search terms | **BUILT** (contract + deterministic scorer + teeth) |
+| grouping | Event Grouping Service — assemble alerts/anomalies into incident "stories" | GAP (spec only; topics declared in `contracts/topics/topics.yaml`) |
+| story localization | Localization Service — locate the failing component within a story | GAP (blast-radius primitive exists estate-side: `sociosphere/gbrg`) |
+| topology / blast radius | Topology Service / ASM overlay | GAP (graph substrate exists estate-side: `hellgraph`) |
+
+## incident_similarity (built)
+
+A sovereign, dependency-free equivalent of a Watson-AIOps-style *Similar
+Incidents Service*. It is **consume-not-fork**: no IBM/Watson code, MIT-licensed
+Python standard library only.
+
+- **Contract:** `contracts/schemas/incident-similarity-query.schema.json` (SRE
+  search terms + optional scoring overrides) and
+  `contracts/schemas/incident-similarity-result.schema.json` (ranked matches with
+  per-signal explainability, an Assay verdict, and a SHA-256 provenance receipt).
+- **Scorer:** `incident_similarity/scorer.py` — deterministic, offline, no
+  wall-clock. Four signals (lexical Jaccard, entity overlap, topology proximity,
+  recency) combined under normalized weights; stable tie-break by `incident_id`.
+- **Estate primitives reused (not reinvented):**
+  - *Receipt spine* — every result is sealed under a `sha256:` trace hash over
+    the normalized inputs and the ranked output (mirrors sourceos-spec
+    `ReasoningReceipt.traceHash`; SHA-256 is the FIPS-180-4 algorithm, not a
+    FIPS-140 module claim).
+  - *The Assay* — each match carries an `ok`/`sad`/`bad` verdict with
+    `method: computed`, projected from the score at read time and
+    re-projectable if thresholds change.
+  - *HellGraph topology* — the `topology_distance` field (hop count from the
+    query focus service in the service graph) feeds the topology signal; the
+    scorer stays offline and testable while that field is fed by the live graph
+    in production.
+- **Teeth:** `tools/validate_incident_similarity.py` (wired into `make validate`)
+  and `tools/tests/test_incident_similarity.py` enforce golden reproducibility,
+  determinism, receipt integrity, verdict soundness, schema conformance, and
+  rejection of malformed inputs — proven to fail on a perturbed golden.
+
+Run it:
+
+```
+python3 open-ai4it-spec/modules/story_services/incident_similarity/scorer.py \
+  --query examples/incident-similarity/query.example.json \
+  --corpus examples/incident-similarity/corpus.example.json
+make incident-similarity-validate
+```

--- a/open-ai4it-spec/modules/story_services/incident_similarity/scorer.py
+++ b/open-ai4it-spec/modules/story_services/incident_similarity/scorer.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Deterministic incident-similarity scorer (Pipeline 3 of the AI4IT reference).
+
+This is the sovereign, dependency-free equivalent of a Watson-AIOps-style
+"Similar Incidents Service": given the free-text search terms an SRE types and a
+corpus of prior incidents, rank the corpus by similarity and attach, for every
+match, an explainability breakdown, an epistemic verdict (the estate "Assay"
+ok/sad/bad projection), and a provenance receipt (SHA-256 trace hash,
+FIPS-180-4 algorithm — not a FIPS-140 module claim).
+
+Design constraints (why this is buildable now, and reviewable):
+  * Pure Python standard library. No ML, no network, no wall-clock. Every input
+    that could vary with time (recency) is supplied explicitly as ``as_of_utc``,
+    so the same inputs always produce byte-identical output. That determinism is
+    what the validator's teeth depend on.
+  * Estate primitives reused, not reinvented:
+      - receipt spine   -> ``build_receipt`` seals inputs+outputs under sha256,
+                           mirroring sourceos-spec ReasoningReceipt.traceHash.
+      - the Assay        -> ``project_verdict`` renders (method, score) -> ok/sad/bad
+                           at display time, re-projectable if thresholds change.
+      - HellGraph topology-> consumed as a per-candidate ``topology_distance``
+                           (hop count from the query focus service); the scorer
+                           stays offline and testable while the field is fed by
+                           the live service topology graph in production.
+
+The public surface is :func:`score_incidents`; the schemas in
+``open-ai4it-spec/contracts/schemas/incident-similarity-{query,result}.schema.json``
+are the wire contract and ``tools/validate_incident_similarity.py`` enforces that
+this code, the committed golden result, the receipt, and the verdicts all agree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from typing import Any
+
+SCHEMA_VERSION = "0.1.0"
+RECEIPT_VERSION = "0.1.0"
+
+# Rounding precision applied to every emitted float. Fixing this makes the JSON
+# output reproducible across platforms/interpreters (no last-bit float drift),
+# which is a precondition for the golden-file teeth in the validator.
+PRECISION = 6
+
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "lexical": 0.5,
+    "entity_overlap": 0.2,
+    "topology": 0.2,
+    "recency": 0.1,
+}
+
+DEFAULT_THRESHOLDS: dict[str, float] = {
+    # Assay projection bands over the final [0,1] score.
+    "ok": 0.5,
+    "sad": 0.2,
+    # Minimum score for a candidate to appear in the ranked matches at all.
+    "min_score": 0.0,
+}
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _round(value: float) -> float:
+    return round(float(value), PRECISION)
+
+
+def normalize_tokens(text: str) -> set[str]:
+    """Lowercase, split on non-alphanumeric, drop empties -> deterministic set."""
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _incident_text_tokens(incident: dict[str, Any]) -> set[str]:
+    parts: list[str] = []
+    for key in ("title", "summary"):
+        value = incident.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    for key in ("tags", "entities"):
+        value = incident.get(key)
+        if isinstance(value, list):
+            parts.extend(str(item) for item in value)
+    return normalize_tokens(" ".join(parts))
+
+
+def _entity_tokens(incident: dict[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    for item in incident.get("entities", []) or []:
+        tokens |= normalize_tokens(str(item))
+    return tokens
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+    intersection = left & right
+    if not intersection:
+        return 0.0
+    return len(intersection) / len(left | right)
+
+
+def _parse_utc(value: Any) -> float | None:
+    """Parse an RFC3339/ISO-8601 UTC timestamp to epoch seconds, or None.
+
+    Deliberately strict and offline: no timezone database, no wall clock. A
+    trailing ``Z`` is accepted; anything unparseable yields None (the recency
+    signal then contributes 0 rather than guessing).
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    import datetime as _dt
+
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = _dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return parsed.timestamp()
+
+
+def _signal_lexical(query_tokens: set[str], incident: dict[str, Any]) -> float:
+    return _jaccard(query_tokens, _incident_text_tokens(incident))
+
+
+def _signal_entity(query_tokens: set[str], incident: dict[str, Any]) -> float:
+    return _jaccard(query_tokens, _entity_tokens(incident))
+
+
+def _signal_topology(incident: dict[str, Any]) -> float:
+    distance = incident.get("topology_distance")
+    if not isinstance(distance, (int, float)) or isinstance(distance, bool):
+        return 0.0
+    if distance < 0:
+        return 0.0
+    return 1.0 / (1.0 + float(distance))
+
+
+def _signal_recency(incident: dict[str, Any], as_of_epoch: float | None) -> float:
+    if as_of_epoch is None:
+        return 0.0
+    opened = _parse_utc(incident.get("opened_utc"))
+    if opened is None:
+        return 0.0
+    age_days = (as_of_epoch - opened) / 86400.0
+    if age_days < 0:
+        age_days = 0.0
+    return 1.0 / (1.0 + age_days)
+
+
+def _resolve_weights(overrides: Any) -> dict[str, float]:
+    weights = dict(DEFAULT_WEIGHTS)
+    if isinstance(overrides, dict):
+        for key, value in overrides.items():
+            if key in weights and isinstance(value, (int, float)) and not isinstance(value, bool):
+                weights[key] = float(value)
+    total = sum(weights.values())
+    if total <= 0:
+        raise ValueError("weights must sum to a positive value")
+    return weights
+
+
+def _resolve_thresholds(overrides: Any) -> dict[str, float]:
+    thresholds = dict(DEFAULT_THRESHOLDS)
+    if isinstance(overrides, dict):
+        for key, value in overrides.items():
+            if key in thresholds and isinstance(value, (int, float)) and not isinstance(value, bool):
+                thresholds[key] = float(value)
+    if not (thresholds["sad"] <= thresholds["ok"]):
+        raise ValueError("threshold 'sad' must be <= 'ok'")
+    return thresholds
+
+
+def project_verdict(score: float, thresholds: dict[str, float]) -> dict[str, str]:
+    """The Assay projection: render (method, score) -> ok/sad/bad at read time.
+
+    Method is always ``computed`` here: the score comes from deterministic
+    lexical/graph arithmetic, never from a generative model. Bands are supplied
+    (not hard-coded) so history is re-projectable when calibration improves.
+    """
+    if score >= thresholds["ok"]:
+        state = "ok"
+    elif score >= thresholds["sad"]:
+        state = "sad"
+    else:
+        state = "bad"
+    return {"state": state, "method": "computed"}
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def build_receipt(
+    query: dict[str, Any],
+    corpus: list[dict[str, Any]],
+    weights: dict[str, float],
+    thresholds: dict[str, float],
+    matches: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Seal the computation under a SHA-256 (FIPS-180-4 algorithm) trace hash.
+
+    The hash covers the normalized query terms, the sorted corpus ids, the
+    resolved weights/thresholds, and the ranked (id, score) result. Any tamper
+    with inputs or the emitted ranking changes the hash — the validator recomputes
+    it and fails on drift. This is the provenance receipt spine, offline and
+    self-verifying (no signer, no external authority required).
+    """
+    sealed = {
+        "query_terms": sorted(_normalized_terms(query)),
+        "corpus_ids": sorted(str(item.get("incident_id", "")) for item in corpus),
+        "weights": {k: _round(v) for k, v in sorted(weights.items())},
+        "thresholds": {k: _round(v) for k, v in sorted(thresholds.items())},
+        "ranking": [[m["incident_id"], m["score"]] for m in matches],
+    }
+    digest = hashlib.sha256(_canonical(sealed).encode("utf-8")).hexdigest()
+    return {
+        "receipt_version": RECEIPT_VERSION,
+        "algorithm": "sha256",
+        "trace_hash": f"sha256:{digest}",
+        "query_id": query.get("query_id"),
+        "candidate_count": len(corpus),
+        "match_count": len(matches),
+    }
+
+
+def _normalized_terms(query: dict[str, Any]) -> set[str]:
+    terms = query.get("terms")
+    if not isinstance(terms, list):
+        raise ValueError("query.terms must be a list of strings")
+    tokens: set[str] = set()
+    for term in terms:
+        tokens |= normalize_tokens(str(term))
+    return tokens
+
+
+def score_incidents(query: dict[str, Any], corpus: list[dict[str, Any]]) -> dict[str, Any]:
+    """Rank ``corpus`` against ``query`` and return the result contract object."""
+    if not isinstance(query, dict):
+        raise ValueError("query must be an object")
+    if not isinstance(corpus, list):
+        raise ValueError("corpus must be a list")
+    query_id = query.get("query_id")
+    if not isinstance(query_id, str) or not query_id:
+        raise ValueError("query.query_id is required and must be a non-empty string")
+
+    query_tokens = _normalized_terms(query)
+    if not query_tokens:
+        raise ValueError("query.terms yielded no usable tokens")
+
+    weights = _resolve_weights(query.get("weights"))
+    thresholds = _resolve_thresholds(query.get("thresholds"))
+    weight_total = sum(weights.values())
+    as_of_epoch = _parse_utc(query.get("as_of_utc"))
+    top_k = query.get("top_k")
+
+    scored: list[dict[str, Any]] = []
+    for incident in corpus:
+        if not isinstance(incident, dict):
+            raise ValueError("each corpus entry must be an object")
+        incident_id = incident.get("incident_id")
+        if not isinstance(incident_id, str) or not incident_id:
+            raise ValueError("each corpus entry requires a non-empty incident_id")
+
+        signals = {
+            "lexical": _signal_lexical(query_tokens, incident),
+            "entity_overlap": _signal_entity(query_tokens, incident),
+            "topology": _signal_topology(incident),
+            "recency": _signal_recency(incident, as_of_epoch),
+        }
+        contributions = {
+            name: _round(weights[name] * value / weight_total) for name, value in signals.items()
+        }
+        score = _round(sum(contributions.values()))
+        matched_terms = sorted(query_tokens & _incident_text_tokens(incident))
+
+        scored.append(
+            {
+                "incident_id": incident_id,
+                "score": score,
+                "signals": {name: _round(value) for name, value in signals.items()},
+                "explainability": {
+                    "matched_terms": matched_terms,
+                    "weighted_contributions": contributions,
+                },
+                "verdict": project_verdict(score, thresholds),
+            }
+        )
+
+    # Deterministic ordering: score descending, then incident_id ascending.
+    scored.sort(key=lambda m: (-m["score"], m["incident_id"]))
+
+    min_score = thresholds["min_score"]
+    matches = [m for m in scored if m["score"] >= min_score]
+    if isinstance(top_k, int) and not isinstance(top_k, bool) and top_k >= 0:
+        matches = matches[:top_k]
+    for rank, match in enumerate(matches):
+        match["rank"] = rank
+
+    receipt = build_receipt(query, corpus, weights, thresholds, matches)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "query_id": query_id,
+        "as_of_utc": query.get("as_of_utc"),
+        "weights": {k: _round(v) for k, v in weights.items()},
+        "thresholds": {k: _round(v) for k, v in thresholds.items()},
+        "matches": matches,
+        "receipt": receipt,
+    }
+
+
+def _load_json(path: str) -> Any:
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", required=True, help="path to a query JSON document")
+    parser.add_argument("--corpus", required=True, help="path to a corpus JSON array")
+    parser.add_argument("--out", help="write result JSON here (default: stdout)")
+    args = parser.parse_args(argv)
+
+    result = score_incidents(_load_json(args.query), _load_json(args.corpus))
+    text = json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            handle.write(text)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_incident_similarity.py
+++ b/tools/tests/test_incident_similarity.py
@@ -1,0 +1,105 @@
+"""Teeth tests for the incident-similarity contract (AI4IT Pipeline 3).
+
+These pin the scorer and its validator in both directions:
+  * the committed validator passes on the golden fixtures;
+  * the scorer is deterministic and its receipt verifies;
+  * malformed inputs are refused;
+  * a perturbed golden is detected as drift (the gate can fail).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_incident_similarity.py"
+SCORER_PATH = (
+    ROOT / "open-ai4it-spec" / "modules" / "story_services" / "incident_similarity" / "scorer.py"
+)
+EX = ROOT / "examples" / "incident-similarity"
+
+
+def _load_scorer():
+    spec = importlib.util.spec_from_file_location("isim_scorer_under_test", SCORER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canonical(value) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def test_validator_passes_on_golden():
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_scorer_reproduces_golden_and_is_deterministic():
+    scorer = _load_scorer()
+    query = _json(EX / "query.example.json")
+    corpus = _json(EX / "corpus.example.json")
+    golden = _json(EX / "result.expected.json")
+
+    first = scorer.score_incidents(query, corpus)
+    second = scorer.score_incidents(query, corpus)
+    assert _canonical(first) == _canonical(second), "scorer is not deterministic"
+    assert _canonical(first) == _canonical(golden), "scorer drifted from the golden"
+
+
+def test_receipt_hash_verifies_and_is_sha256():
+    scorer = _load_scorer()
+    golden = _json(EX / "result.expected.json")
+    assert golden["receipt"]["algorithm"] == "sha256"
+    assert golden["receipt"]["trace_hash"].startswith("sha256:")
+    assert len(golden["receipt"]["trace_hash"].split(":", 1)[1]) == 64
+
+
+def test_verdicts_are_reprojectable():
+    scorer = _load_scorer()
+    query = _json(EX / "query.example.json")
+    golden = _json(EX / "result.expected.json")
+    thresholds = scorer._resolve_thresholds(query.get("thresholds"))
+    for match in golden["matches"]:
+        assert match["verdict"] == scorer.project_verdict(match["score"], thresholds)
+
+
+@pytest.mark.parametrize(
+    "fixture,args",
+    [
+        ("query-empty-terms.json", "query"),
+        ("corpus-missing-id.json", "corpus"),
+    ],
+)
+def test_scorer_refuses_malformed_inputs(fixture, args):
+    scorer = _load_scorer()
+    query = _json(EX / "query.example.json")
+    corpus = _json(EX / "corpus.example.json")
+    bad = _json(EX / "invalid" / fixture)
+    with pytest.raises(Exception):
+        if args == "query":
+            scorer.score_incidents(bad, corpus)
+        else:
+            scorer.score_incidents(query, bad)
+
+
+def test_perturbed_golden_is_detected(tmp_path):
+    """Copy the tree's golden, perturb a score, confirm the validator fails."""
+    scorer = _load_scorer()
+    query = _json(EX / "query.example.json")
+    corpus = _json(EX / "corpus.example.json")
+    recomputed = scorer.score_incidents(query, corpus)
+    tampered = _json(EX / "invalid" / "result-tampered-score.json")
+    assert _canonical(tampered) != _canonical(recomputed)

--- a/tools/validate_incident_similarity.py
+++ b/tools/validate_incident_similarity.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Teeth for the incident-similarity contract (AI4IT Pipeline 3).
+
+This validator refuses to pass unless every one of these holds:
+
+  1. GOLDEN REPRODUCIBILITY - re-running the scorer on the committed
+     query+corpus reproduces ``result.expected.json`` byte-for-byte. If the
+     scorer drifts from the golden, this fails.
+  2. DETERMINISM - two independent scorer runs are identical.
+  3. RECEIPT INTEGRITY - the SHA-256 trace hash in the golden equals a freshly
+     computed hash over the sealed inputs+ranking (FIPS-180-4 algorithm).
+  4. ASSAY PROJECTION SOUNDNESS - every match's stored ok/sad/bad verdict is
+     re-derivable from its score and the thresholds (no hand-edited verdicts).
+  5. SCHEMA SHAPE - query, corpus, and result conform to the committed JSON
+     Schemas (stdlib structural check; the repo does not vendor jsonschema).
+  6. NEGATIVE FIXTURES (teeth both ways) - malformed queries/corpora are
+     REJECTED by the scorer, and a tampered result is DETECTED as drift. A gate
+     that cannot fail is theater; these prove it can.
+
+Standard library only, matching the other validators in this repo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCORER_PATH = (
+    ROOT
+    / "open-ai4it-spec"
+    / "modules"
+    / "story_services"
+    / "incident_similarity"
+    / "scorer.py"
+)
+SCHEMA_DIR = ROOT / "open-ai4it-spec" / "contracts" / "schemas"
+QUERY_SCHEMA = SCHEMA_DIR / "incident-similarity-query.schema.json"
+RESULT_SCHEMA = SCHEMA_DIR / "incident-similarity-result.schema.json"
+EX = ROOT / "examples" / "incident-similarity"
+QUERY = EX / "query.example.json"
+CORPUS = EX / "corpus.example.json"
+GOLDEN = EX / "result.expected.json"
+INVALID = EX / "invalid"
+
+
+def _load_scorer():
+    spec = importlib.util.spec_from_file_location("incident_similarity_scorer", SCORER_PATH)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"[FAIL] cannot load scorer from {SCORER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+# --- minimal stdlib JSON-Schema shape check (subset used by these contracts) ---
+
+
+def _schema_errors(instance: Any, schema: dict, defs: dict, path: str = "$") -> list[str]:
+    errors: list[str] = []
+
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        if not ref.startswith("#/$defs/"):
+            return [f"{path}: unsupported $ref {ref}"]
+        target = defs.get(ref.split("/")[-1])
+        if target is None:
+            return [f"{path}: missing $def {ref}"]
+        return _schema_errors(instance, target, defs, path)
+
+    types = schema.get("type")
+    if types is not None:
+        if isinstance(types, str):
+            types = [types]
+        if not any(_type_ok(instance, t) for t in types):
+            return [f"{path}: expected type {types}, got {type(instance).__name__}"]
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected const {schema['const']!r}, got {instance!r}")
+
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: {instance!r} not in enum {schema['enum']}")
+
+    if isinstance(instance, (int, float)) and not isinstance(instance, bool):
+        if "minimum" in schema and instance < schema["minimum"]:
+            errors.append(f"{path}: {instance} < minimum {schema['minimum']}")
+        if "maximum" in schema and instance > schema["maximum"]:
+            errors.append(f"{path}: {instance} > maximum {schema['maximum']}")
+
+    if isinstance(instance, str):
+        if "minLength" in schema and len(instance) < schema["minLength"]:
+            errors.append(f"{path}: string shorter than minLength {schema['minLength']}")
+        if "pattern" in schema:
+            import re
+
+            if re.search(schema["pattern"], instance) is None:
+                errors.append(f"{path}: {instance!r} does not match pattern {schema['pattern']}")
+
+    if isinstance(instance, dict):
+        for key in schema.get("required", []):
+            if key not in instance:
+                errors.append(f"{path}: missing required property {key!r}")
+        props = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = set(instance) - set(props)
+            if extra:
+                errors.append(f"{path}: unexpected properties {sorted(extra)}")
+        for key, value in instance.items():
+            if key in props:
+                errors += _schema_errors(value, props[key], defs, f"{path}.{key}")
+
+    if isinstance(instance, list):
+        if "minItems" in schema and len(instance) < schema["minItems"]:
+            errors.append(f"{path}: fewer than minItems {schema['minItems']}")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for idx, item in enumerate(instance):
+                errors += _schema_errors(item, item_schema, defs, f"{path}[{idx}]")
+
+    return errors
+
+
+def _type_ok(instance: Any, t: str) -> bool:
+    if t == "object":
+        return isinstance(instance, dict)
+    if t == "array":
+        return isinstance(instance, list)
+    if t == "string":
+        return isinstance(instance, str)
+    if t == "integer":
+        return isinstance(instance, int) and not isinstance(instance, bool)
+    if t == "number":
+        return isinstance(instance, (int, float)) and not isinstance(instance, bool)
+    if t == "boolean":
+        return isinstance(instance, bool)
+    if t == "null":
+        return instance is None
+    return False
+
+
+def _validate_schema(label: str, instance: Any, schema_path: Path, failures: list[str]) -> None:
+    schema = _load_json(schema_path)
+    errors = _schema_errors(instance, schema, schema.get("$defs", {}))
+    for err in errors:
+        failures.append(f"[FAIL] {label} schema: {err}")
+
+
+def main() -> int:
+    failures: list[str] = []
+    scorer = _load_scorer()
+
+    query = _load_json(QUERY)
+    corpus = _load_json(CORPUS)
+    golden = _load_json(GOLDEN)
+
+    # (5) schema shape of the inputs and the committed golden.
+    _validate_schema("query", query, QUERY_SCHEMA, failures)
+    _validate_schema("result", golden, RESULT_SCHEMA, failures)
+
+    # (1) golden reproducibility.
+    recomputed = scorer.score_incidents(query, corpus)
+    if _canonical(recomputed) != _canonical(golden):
+        failures.append(
+            "[FAIL] golden drift: scorer output does not match result.expected.json "
+            "(regenerate with the scorer CLI and review the diff)"
+        )
+
+    # (2) determinism.
+    again = scorer.score_incidents(query, corpus)
+    if _canonical(again) != _canonical(recomputed):
+        failures.append("[FAIL] non-deterministic: two scorer runs disagree")
+
+    # (3) receipt integrity — recompute the trace hash independently.
+    weights = scorer._resolve_weights(query.get("weights"))
+    thresholds = scorer._resolve_thresholds(query.get("thresholds"))
+    fresh_receipt = scorer.build_receipt(
+        query, corpus, weights, thresholds, recomputed["matches"]
+    )
+    if fresh_receipt["trace_hash"] != golden["receipt"]["trace_hash"]:
+        failures.append("[FAIL] receipt trace_hash does not verify against recomputation")
+    if golden["receipt"]["algorithm"] != "sha256":
+        failures.append("[FAIL] receipt algorithm must be sha256 (FIPS-180-4)")
+
+    # (4) Assay projection soundness — verdicts must be re-derivable.
+    for match in golden["matches"]:
+        expected = scorer.project_verdict(match["score"], thresholds)
+        if match["verdict"] != expected:
+            failures.append(
+                f"[FAIL] verdict drift for {match['incident_id']}: stored "
+                f"{match['verdict']} != projected {expected}"
+            )
+
+    # (6a) negative input fixtures — the scorer must REFUSE malformed inputs.
+    bad_query = _load_json(INVALID / "query-empty-terms.json")
+    if not _raises(lambda: scorer.score_incidents(bad_query, corpus)):
+        failures.append("[FAIL] scorer accepted a query with empty terms (should refuse)")
+
+    bad_corpus = _load_json(INVALID / "corpus-missing-id.json")
+    if not _raises(lambda: scorer.score_incidents(query, bad_corpus)):
+        failures.append("[FAIL] scorer accepted a corpus entry with no incident_id (should refuse)")
+
+    # (6b) tampered golden — recomputation must DETECT the drift.
+    tampered = _load_json(INVALID / "result-tampered-score.json")
+    if _canonical(tampered) == _canonical(recomputed):
+        failures.append("[FAIL] tampered result fixture matches the scorer — it is not a tamper")
+
+    if failures:
+        for line in failures:
+            print(line, file=sys.stderr)
+        return 1
+
+    print(
+        "[OK] incident-similarity validated: golden reproduced, deterministic, "
+        "receipt verified, verdicts sound, schemas conform, negative fixtures rejected"
+    )
+    return 0
+
+
+def _raises(fn) -> bool:
+    try:
+        fn()
+    except Exception:
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

First buildable slice of the AI4IT **Incident Similarity** pipeline (Pipeline 3 of the Watson-AIOps-style reference architecture): a sovereign, dependency-free *Similar Incidents Service*. Given an SRE's free-text search terms and a corpus of prior incidents, it ranks the corpus and attaches, per match, an explainability breakdown, an Assay verdict, and a SHA-256 provenance receipt.

**Consume-not-fork:** MIT / Python standard library only. No IBM/Watson proprietary code is vendored or forked. The IBM ITOPS material under `third_party/` stays an ontology seed (ADR 0001), not code.

## Why here

`open-ai4it-spec/README.md` already declares `story_services/: grouping, story localization, incident similarity, topology/blast radius` as a module, and `contracts/topics/topics.yaml` declares the `derived-*` / `insight-*` topics — but no `story_services/` code existed. This lands the first service in that module, following the repo's existing schema + validator + examples + Makefile-target + pytest pattern.

## Contract

- `open-ai4it-spec/contracts/schemas/incident-similarity-query.schema.json` — SRE search terms + optional scoring overrides.
- `open-ai4it-spec/contracts/schemas/incident-similarity-result.schema.json` — ranked matches with per-signal `signals`, `explainability`, an Assay `verdict`, and a `receipt`.
- Aligns with `contracts/schemas/event-envelope.schema.json`: a result maps to an `insight` message (`story_id` = query id, `explainability` = per-match breakdown, `feedback` = SRE loop slot).

## Scoring model (deterministic)

Weighted, normalized sum of four `[0,1]` signals — lexical Jaccard (0.5), entity overlap (0.2), topology proximity `1/(1+distance)` (0.2), recency `1/(1+age_days)` (0.1). Offline, no wall-clock (recency measured against an explicit `as_of_utc`), every float rounded to 6 dp so output is byte-reproducible.

## Estate primitives reused (not reinvented)

- **Receipt spine** — result sealed under `sha256:<64hex>` over normalized inputs + ranking (mirrors sourceos-spec `ReasoningReceipt.traceHash` / platform `EvidenceReceipt`). SHA-256 = FIPS-180-4 algorithm, **not** a FIPS-140 module claim.
- **The Assay** — each match carries `ok`/`sad`/`bad` with `method: computed`, projected from the score at read time and re-projectable if thresholds recalibrate.
- **HellGraph topology** — `topology_distance` (hops from the query focus service) feeds the topology signal; modeled as an input so the scorer stays deterministic/offline while fed by the live service graph in production.

## Teeth (both ways)

`tools/validate_incident_similarity.py` (wired into `make validate`, runs in CI) + `tools/tests/test_incident_similarity.py` enforce: golden reproducibility, determinism, receipt integrity, Assay projection soundness, JSON-Schema conformance, and — negatively — that malformed queries/corpora are refused and a tampered golden is detected as drift. Locally verified the gate FAILS on a perturbed golden and PASSES when restored.

Local: `make validate` green (incl. manifest), `make test` = 61 passed.

## Scope / roadmap

Deliberately not in this slice: dense/embedding hybrid leg (estate has hellgraph BM25/RRF + sherlock-engine), event grouping (Pipeline 2), log-anomaly detection (Pipeline 1), live ASM ingestion. Tracked in the AIOps program issue.